### PR TITLE
Bump the version and trigger a release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@datadog/js-instrumentation-wasm",
   "type": "module",
-  "version": "0.2.0",
+  "version": "0.9.0",
   "license": "MIT",
   "description": "A library for adding Datadog instrumentation to JavaScript and TypeScript code",
   "homepage": "https://github.com/datadog/js-instrumentation-wasm#readme",


### PR DESCRIPTION
## Description

We should now be ready to trigger our first NPM release! Since we're now in the experimental early release phase, I've bumped the version to `0.9.0`.