### PR TITLE
Use an in-repo action to trigger releases

### DIFF
--- a/.github/actions/check-release-status/action.yml
+++ b/.github/actions/check-release-status/action.yml
@@ -1,0 +1,22 @@
+name: 'Check Release Status'
+description: 'Check if the current package.json version has already been released.'
+outputs:
+  already-released:
+    description: 'Set to true when the current package.json version has already been released.'
+    value: ${{ steps.check-releases-list.outputs.already-released }}
+runs:
+  using: "composite"
+  steps:
+    - name: Check if version appears in releases list
+      id: check-releases-list
+      shell: bash
+      run: |
+        PACKAGE_VERSION=$(jq -r .version < package.json)
+        echo "PACKAGE_VERSION=${PACKAGE_VERSION}"
+        if gh release list | grep -q "^${PACKAGE_VERSION}\W"; then
+          echo "This version has already been released."
+          echo "already-released=true" >> $GITHUB_OUTPUT
+        else
+          echo "This version has not yet been released."
+          echo "already-released=false" >> $GITHUB_OUTPUT
+        fi

--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -14,3 +14,9 @@ runs:
     - name: Run yarn npm publish
       run: yarn npm publish
       shell: bash
+    - name: Create a Github release
+      shell: bash
+      run: |
+        PACKAGE_VERSION=$(jq -r .version < package.json)
+        echo "PACKAGE_VERSION=${PACKAGE_VERSION}"
+        gh release create "${PACKAGE_VERSION}" --generate-notes

--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -30,15 +30,11 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0
-    - name: Check if release is necessary
-      uses: justincy/github-action-npm-release@f6afd60cbb595a76ecae037ad006671636d321f5 # v2.0.2
-      id: release
-    - name: Print release output
-      if: steps.release.outputs.released == 'true'
-      run: echo Release ID ${{ steps.release.outputs.release_id }}
+    - uses: ./.github/actions/check-release-status/
+      id: release-status
     - uses: ./.github/actions/build/
       with:
         mode: "release"
-      if: steps.release.outputs.released == 'true'
+      if: steps.release-status.outputs.already-released == 'false'
     - uses: ./.github/actions/publish/
-      if: steps.release.outputs.released == 'true'
+      if: steps.release-status.outputs.already-released == 'false'


### PR DESCRIPTION
## Description

Because of the security settings for this repo, the Github Action we were previously using for triggering releases is no longer allowed, so we need to switch to an in-repo solution.

This PR implements an in-repo "Check Release Status" action that checks if the current `package.json` version corresponds to an existing release. The "Trigger Release" workflow now uses this action to determine whether a new release is needed. The existing "Publish" action now both publishes to NPM and creates a new Github release. Combined, these changes restore the old functionality, without a dependency on an externally-defined Github Action.