### PR TITLE
Set GH_TOKEN when using gh in actions

### DIFF
--- a/.github/actions/check-release-status/action.yml
+++ b/.github/actions/check-release-status/action.yml
@@ -10,6 +10,8 @@ runs:
     - name: Check if version appears in releases list
       id: check-releases-list
       shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         PACKAGE_VERSION=$(jq -r .version < package.json)
         echo "PACKAGE_VERSION=${PACKAGE_VERSION}"

--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -16,6 +16,8 @@ runs:
       shell: bash
     - name: Create a Github release
       shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         PACKAGE_VERSION=$(jq -r .version < package.json)
         echo "PACKAGE_VERSION=${PACKAGE_VERSION}"


### PR DESCRIPTION
## Description

This is a fast-follow for #8; it looks like we need to set `GH_TOKEN` to use `gh` inside a Github Action.