### PR TITLE
Pass NPM_PUBLISH_TOKEN into actions

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -1,11 +1,15 @@
 name: 'Publish'
 description: 'Publish the package to NPM'
+inputs:
+  npm_publish_token:
+    description: "NPM_PUBLISH_TOKEN"
+    required: true
 runs:
   using: "composite"
   steps:
     - name: Set up authentication for package publishing
       env:
-        NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+        NPM_PUBLISH_TOKEN: ${{ inputs.npm_publish_token }}
       run: yarn config set npmAuthToken $NPM_PUBLISH_TOKEN
       shell: bash
     - name: Run yarn workspaces focus

--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -31,3 +31,5 @@ jobs:
       with:
         mode: "release"
     - uses: ./.github/actions/publish/
+      with:
+        npm_publish_token: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -37,4 +37,6 @@ jobs:
         mode: "release"
       if: steps.release-status.outputs.already-released == 'false'
     - uses: ./.github/actions/publish/
+      with:
+        npm_publish_token: ${{ secrets.NPM_PUBLISH_TOKEN }}
       if: steps.release-status.outputs.already-released == 'false'


### PR DESCRIPTION
## Description

The "Publish" action seems to be having trouble accessing `secrets.NPM_PUBLISH_TOKEN`. I notice that in the old version of the action, we passed in this value as an input to the action; it may be that secrets are only directly accessible in the workflow, and must be passed elsewhere explicitly, which would make sense from a security perspective. This PR makes us pass this secret into the "Publish" action from the workflows that use it.