### PR TITLE
Make instrument function synchronous

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,7 +17,10 @@ const plugins = () =>
     commonjs(),
     json(),
     wasm({
-      targetEnv: 'auto-inline'
+      targetEnv: 'auto-inline',
+      sync: [
+        'rust/datadog-js-instrumentation/pkg/datadog_js_instrumentation_bg.wasm'
+      ]
     }),
   ];
 

--- a/tests/instrumentation-test-plugin/src/core/unplugin.ts
+++ b/tests/instrumentation-test-plugin/src/core/unplugin.ts
@@ -75,8 +75,8 @@ export const unpluginFactory: UnpluginFactory<UnpluginOptions> = options => {
     transform: {
       order: 'pre',
 
-      async handler(code, id) {
-        const result = await instrument({ id, code }, instrumentationOptions);
+      handler(code, id) {
+        const result = instrument({ id, code }, instrumentationOptions);
         return { code: result.code, map: result.map };
       },
     },

--- a/tests/instrumentation-test-plugin/yarn.lock
+++ b/tests/instrumentation-test-plugin/yarn.lock
@@ -150,8 +150,8 @@ __metadata:
 
 "@datadog/js-instrumentation-wasm@file:../../artifacts/@datadog-js-instrumentation-wasm.tgz::locator=%40datadog%2Finstrumentation-test-plugin%40workspace%3A.":
   version: 0.9.3
-  resolution: "@datadog/js-instrumentation-wasm@file:../../artifacts/@datadog-js-instrumentation-wasm.tgz#../../artifacts/@datadog-js-instrumentation-wasm.tgz::hash=a3de7f&locator=%40datadog%2Finstrumentation-test-plugin%40workspace%3A."
-  checksum: 10c0/4d86b0307d98f33badb45ca058e05f97ca1cb152914cb58f6b7272bf344294a4bbcea258f4b46c252c64f88fcc5c186f53d6d97ea37b00ff8f37e3a699ae4461
+  resolution: "@datadog/js-instrumentation-wasm@file:../../artifacts/@datadog-js-instrumentation-wasm.tgz#../../artifacts/@datadog-js-instrumentation-wasm.tgz::hash=9776a8&locator=%40datadog%2Finstrumentation-test-plugin%40workspace%3A."
+  checksum: 10c0/b9f437ffaa4040f58c9909820dc2bc5e4796e0142640ab1f6ba99d44e3943bc5c343149ba830c8392c58e1247e5d170c99cc494a7ee3d0c9fe22e7e3fbd01a12
   languageName: node
   linkType: hard
 

--- a/tests/integration/esbuild/yarn.lock
+++ b/tests/integration/esbuild/yarn.lock
@@ -93,7 +93,7 @@ __metadata:
 
 "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::locator=esbuild-project%40workspace%3A.":
   version: 0.1
-  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=aa62ac&locator=esbuild-project%40workspace%3A."
+  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=6a5be8&locator=esbuild-project%40workspace%3A."
   dependencies:
     unplugin: "npm:^2.3.4"
   peerDependencies:
@@ -119,7 +119,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/ee6199a8aa6b269b42dcf91bfcee8809f957d8feb128e99db314742cfec301bd544e00a533e2cdb208cec90106ee84d360bb68128f77af3b0b6f699d3d3e6216
+  checksum: 10c0/d2281aab9e25d65683fea1f9d1a4e95d43aa2a9cfc9b2c5fcc52ad9cefb4eb78b8750110e19698b2a688af0b99ed06991c9e43ba67323eb8862d9a74e8056ea9
   languageName: node
   linkType: hard
 

--- a/tests/integration/vite-with-yarn-pnp/yarn.lock
+++ b/tests/integration/vite-with-yarn-pnp/yarn.lock
@@ -282,7 +282,7 @@ __metadata:
 
 "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::locator=vite-project%40workspace%3A.":
   version: 0.1
-  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=aa62ac&locator=vite-project%40workspace%3A."
+  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=6a5be8&locator=vite-project%40workspace%3A."
   dependencies:
     unplugin: "npm:^2.3.4"
   peerDependencies:
@@ -308,7 +308,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/ee6199a8aa6b269b42dcf91bfcee8809f957d8feb128e99db314742cfec301bd544e00a533e2cdb208cec90106ee84d360bb68128f77af3b0b6f699d3d3e6216
+  checksum: 10c0/d2281aab9e25d65683fea1f9d1a4e95d43aa2a9cfc9b2c5fcc52ad9cefb4eb78b8750110e19698b2a688af0b99ed06991c9e43ba67323eb8862d9a74e8056ea9
   languageName: node
   linkType: hard
 

--- a/tests/integration/vite/yarn.lock
+++ b/tests/integration/vite/yarn.lock
@@ -282,7 +282,7 @@ __metadata:
 
 "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::locator=vite-project%40workspace%3A.":
   version: 0.1
-  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=aa62ac&locator=vite-project%40workspace%3A."
+  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=6a5be8&locator=vite-project%40workspace%3A."
   dependencies:
     unplugin: "npm:^2.3.4"
   peerDependencies:
@@ -308,7 +308,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/ee6199a8aa6b269b42dcf91bfcee8809f957d8feb128e99db314742cfec301bd544e00a533e2cdb208cec90106ee84d360bb68128f77af3b0b6f699d3d3e6216
+  checksum: 10c0/d2281aab9e25d65683fea1f9d1a4e95d43aa2a9cfc9b2c5fcc52ad9cefb4eb78b8750110e19698b2a688af0b99ed06991c9e43ba67323eb8862d9a74e8056ea9
   languageName: node
   linkType: hard
 

--- a/tests/integration/webpack/yarn.lock
+++ b/tests/integration/webpack/yarn.lock
@@ -93,7 +93,7 @@ __metadata:
 
 "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::locator=webpack-react-typescript-example%40workspace%3A.":
   version: 0.1
-  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=aa62ac&locator=webpack-react-typescript-example%40workspace%3A."
+  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=6a5be8&locator=webpack-react-typescript-example%40workspace%3A."
   dependencies:
     unplugin: "npm:^2.3.4"
   peerDependencies:
@@ -119,7 +119,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/ee6199a8aa6b269b42dcf91bfcee8809f957d8feb128e99db314742cfec301bd544e00a533e2cdb208cec90106ee84d360bb68128f77af3b0b6f699d3d3e6216
+  checksum: 10c0/d2281aab9e25d65683fea1f9d1a4e95d43aa2a9cfc9b2c5fcc52ad9cefb4eb78b8750110e19698b2a688af0b99ed06991c9e43ba67323eb8862d9a74e8056ea9
   languageName: node
   linkType: hard
 

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -21,7 +21,7 @@ const transformCJS = unpluginCJS.raw(pluginOptions).transform.handler;
 describe('the ESM version should transform code correctly', async () => {
   await walkDir(fixtureDir, async (testCase) => {
     it(`should transform ${testCase.dir} correctly`, async () => {
-      const { code } = await transformESM(testCase.code, testCase.name);
+      const { code } = transformESM(testCase.code, testCase.name);
       expect(code).toMatchSnapshot();
     });
   });
@@ -30,7 +30,7 @@ describe('the ESM version should transform code correctly', async () => {
 describe('the CJS version should transform code correctly', async () => {
   await walkDir(fixtureDir, async (testCase) => {
     it(`should transform ${testCase.dir} correctly`, async () => {
-      const { code } = await transformCJS(testCase.code, testCase.name);
+      const { code } = transformCJS(testCase.code, testCase.name);
       expect(code).toMatchSnapshot();
     });
   });

--- a/tests/unit/yarn.lock
+++ b/tests/unit/yarn.lock
@@ -92,7 +92,7 @@ __metadata:
 
 "@datadog/instrumentation-test-plugin@file:../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::locator=%40datadog%2Fjs-instrumentation-wasm-unit-tests%40workspace%3A.":
   version: 0.1
-  resolution: "@datadog/instrumentation-test-plugin@file:../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=aa62ac&locator=%40datadog%2Fjs-instrumentation-wasm-unit-tests%40workspace%3A."
+  resolution: "@datadog/instrumentation-test-plugin@file:../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=6a5be8&locator=%40datadog%2Fjs-instrumentation-wasm-unit-tests%40workspace%3A."
   dependencies:
     unplugin: "npm:^2.3.4"
   peerDependencies:
@@ -118,7 +118,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/ee6199a8aa6b269b42dcf91bfcee8809f957d8feb128e99db314742cfec301bd544e00a533e2cdb208cec90106ee84d360bb68128f77af3b0b6f699d3d3e6216
+  checksum: 10c0/d2281aab9e25d65683fea1f9d1a4e95d43aa2a9cfc9b2c5fcc52ad9cefb4eb78b8750110e19698b2a688af0b99ed06991c9e43ba67323eb8862d9a74e8056ea9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

This PR makes the exported `instrument()` function synchronous; it no longer returns a promise. It turns out that if we want to use `@datadog/js-instrumentation-wasm` as a Jest transformer, we need to offer a synchronous version of `instrument()`, and given that the actual WASM code runs synchronously, we may as well make the synchronous version the only version. The only thing that was asynchronous before was _loading_ the WASM module; this PR makes that synchronous.