### PR TITLE
Use separate CJS and ESM helper modules

### DIFF
--- a/rust/js-instrumentation-shared/src/transform_options.rs
+++ b/rust/js-instrumentation-shared/src/transform_options.rs
@@ -18,9 +18,16 @@ pub struct InputOptions {
 
 #[derive(Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[serde(rename_all_fields = "camelCase")]
 pub enum HelperFunctionSource {
-    Expression { code: String },
-    Import { module: String, func: String },
+    Expression {
+        code: String,
+    },
+    Import {
+        cjs_module: String,
+        esm_module: String,
+        func: String,
+    },
 }
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -46,7 +53,8 @@ impl Default for TransformOptions {
             },
             privacy: PrivacyOptions {
                 add_to_dictionary_helper: HelperFunctionSource::Import {
-                    module: "datadog:privacy-helpers".into(),
+                    cjs_module: "datadog:privacy-helpers.cjs".into(),
+                    esm_module: "datadog:privacy-helpers.mjs".into(),
                     func: "$".into(),
                 },
             },

--- a/rust/js-instrumentation-transform/src/rewrite/privacy_rewrite_template.rs
+++ b/rust/js-instrumentation-transform/src/rewrite/privacy_rewrite_template.rs
@@ -146,29 +146,33 @@ fn build_helper_declaration(params: &TemplateParameters) -> String {
             "const {} = {};\n",
             params.add_to_dictionary_helper_identifier, code
         ),
-        HelperFunctionSource::Import { module, func } => match params.module_kind {
+        HelperFunctionSource::Import {
+            cjs_module,
+            esm_module,
+            func,
+        } => match params.module_kind {
             ModuleKind::CJS if &params.add_to_dictionary_helper_identifier == func => {
                 format!(
                     "const {{ {} }} = require('{}');\n",
-                    params.add_to_dictionary_helper_identifier, module,
+                    params.add_to_dictionary_helper_identifier, cjs_module,
                 )
             }
             ModuleKind::CJS => {
                 format!(
                     "const {{ {}: {} }} = require('{}');\n",
-                    func, params.add_to_dictionary_helper_identifier, module,
+                    func, params.add_to_dictionary_helper_identifier, cjs_module,
                 )
             }
             ModuleKind::ESM if &params.add_to_dictionary_helper_identifier == func => {
                 format!(
                     "import {{ {} }} from '{}';\n",
-                    params.add_to_dictionary_helper_identifier, module,
+                    params.add_to_dictionary_helper_identifier, esm_module,
                 )
             }
             ModuleKind::ESM => {
                 format!(
                     "import {{ {} as {} }} from '{}';\n",
-                    func, params.add_to_dictionary_helper_identifier, module,
+                    func, params.add_to_dictionary_helper_identifier, esm_module,
                 )
             }
         },

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,34 +36,48 @@ export interface InputOptions {
   typescript?: boolean;
 }
 
+/**
+ * Declare the helper using the given JavaScript expression.
+ *
+ * Example: `{ code: '(v) => console.log(v)' }` will produce output like:
+ * ```js
+ *   const $ = (v) => console.log(v);
+ * ```
+ */
+export type ExpressionPrivacyHelperSource = {
+  expression: { code: string };
+};
+
+/**
+ * Declare the helper by importing the given function from the given module.
+ *
+ * Example:
+ * ```js
+ *   {
+ *     cjsModule: 'custom/helpers.cjs',
+ *     esmModule: 'custom/helpers.mjs',
+ *     func: 'foo'
+ *   }
+ * ```
+ * will produce output like:
+ * ```js
+ *   import { foo as $ } from 'custom/helpers.mjs';
+ * ```
+ *
+ * If the input is an ES module, `import` will be used to import `esmModule`;
+ * likewise, for CommonJS modules, `require()` will be used to import `cjsModule`.
+ */
+export type ImportPrivacyHelperSource = {
+  import: {
+    cjsModule: string;
+    esmModule: string;
+    func: string;
+  }
+};
+
 export type PrivacyHelperSource =
-  {
-    /**
-     * Declare the helper using the given JavaScript expression.
-     *
-     * Example: `{ code: '(v) => console.log(v)' }` will produce output like:
-     * ```js
-     *   const $ = (v) => console.log(v);
-     * ```
-     */
-    expression: { code: string };
-  } | {
-    /**
-     * Declare the helper by importing the given function from the given module.
-     *
-     * Example: `{ module: 'custom/helpers', func: 'foo' }` will produce output like:
-     * ```js
-     *   import { foo as $ } from 'custom/helpers';
-     * ```
-     *
-     * If the input is an ES module, `import` will be used; for CommonJS modules,
-     * `require()` will be used.
-     */
-    import: {
-      module: string;
-      func: string;
-    }
-  };
+  | ExpressionPrivacyHelperSource
+  | ImportPrivacyHelperSource;
 
 export interface PrivacyOptions {
   /** The source for the helper function used to add strings to the dictionary. */
@@ -103,7 +117,8 @@ function convertOptions(
     privacy: {
       addToDictionaryHelper: options?.privacy?.addToDictionaryHelper ?? {
         import: {
-          module: 'datadog:privacy-helpers',
+          cjsModule: 'datadog:privacy-helpers.cjs',
+          esmModule: 'datadog:privacy-helpers.mjs',
           func: '$',
         }
       }

--- a/tests/fixtures/common-cases/output.js
+++ b/tests/fixtures/common-cases/output.js
@@ -1,4 +1,4 @@
-import { $ } from 'datadog:privacy-helpers';
+import { $ } from 'datadog:privacy-helpers.mjs';
 const D = $([
   "some string",
   `something`,

--- a/tests/fixtures/commonjs-require/input.js
+++ b/tests/fixtures/commonjs-require/input.js
@@ -1,0 +1,2 @@
+const foo = require('foo-module');
+foo('test');

--- a/tests/fixtures/commonjs-require/output.js
+++ b/tests/fixtures/commonjs-require/output.js
@@ -1,0 +1,6 @@
+const { $ } = require('datadog:privacy-helpers.cjs');
+const D = $([
+  'test',
+]);
+const foo = require('foo-module');
+foo(D[0]);

--- a/tests/fixtures/conflict/output.js
+++ b/tests/fixtures/conflict/output.js
@@ -1,4 +1,4 @@
-import { $ as B } from 'datadog:privacy-helpers';
+import { $ as B } from 'datadog:privacy-helpers.mjs';
 const A = B([
   "test",
 ]);

--- a/tests/fixtures/jsx/output.jsx
+++ b/tests/fixtures/jsx/output.jsx
@@ -1,4 +1,4 @@
-import { $ } from 'datadog:privacy-helpers';
+import { $ } from 'datadog:privacy-helpers.mjs';
 const D = $([
   "Escape special characters with the \"\\\" character.",
   "Text content. With more than one line. And another.",

--- a/tests/fixtures/reference-size/output.js
+++ b/tests/fixtures/reference-size/output.js
@@ -1,4 +1,4 @@
-import { $ } from 'datadog:privacy-helpers';
+import { $ } from 'datadog:privacy-helpers.mjs';
 const D = $([
   "abcd",
   `abcdefghi`,

--- a/tests/fixtures/regular-expressions/output.js
+++ b/tests/fixtures/regular-expressions/output.js
@@ -1,4 +1,4 @@
-import { $ } from 'datadog:privacy-helpers';
+import { $ } from 'datadog:privacy-helpers.mjs';
 const D = $([
   `"`,
 ]);

--- a/tests/fixtures/string-literals/output.js
+++ b/tests/fixtures/string-literals/output.js
@@ -1,4 +1,4 @@
-import { $ } from 'datadog:privacy-helpers';
+import { $ } from 'datadog:privacy-helpers.mjs';
 const D = $([
   "appendix",
   "gem`'\"\u{6F}",

--- a/tests/fixtures/switch-statements/output.js
+++ b/tests/fixtures/switch-statements/output.js
@@ -1,4 +1,4 @@
-import { $ } from 'datadog:privacy-helpers';
+import { $ } from 'datadog:privacy-helpers.mjs';
 const D = $([
   'francis',
   'result',

--- a/tests/fixtures/tagged-templates-only/output.js
+++ b/tests/fixtures/tagged-templates-only/output.js
@@ -1,4 +1,4 @@
-import { $ } from 'datadog:privacy-helpers';
+import { $ } from 'datadog:privacy-helpers.mjs';
 const D = $([
   $`bar${0}`,
 ]);

--- a/tests/fixtures/templates/output.js
+++ b/tests/fixtures/templates/output.js
@@ -1,4 +1,4 @@
-import { $ } from 'datadog:privacy-helpers';
+import { $ } from 'datadog:privacy-helpers.mjs';
 const D = $([
   `\`'"\u{6F}`,
   `abc\r\n\t123`,

--- a/tests/fixtures/ternary-expressions/output.js
+++ b/tests/fixtures/ternary-expressions/output.js
@@ -1,4 +1,4 @@
-import { $ } from 'datadog:privacy-helpers';
+import { $ } from 'datadog:privacy-helpers.mjs';
 const D = $([
   'katherine',
   "charles",

--- a/tests/fixtures/trivial/output.js
+++ b/tests/fixtures/trivial/output.js
@@ -1,4 +1,4 @@
-import { $ } from 'datadog:privacy-helpers';
+import { $ } from 'datadog:privacy-helpers.mjs';
 const D = $([
   "test",
 ]);

--- a/tests/fixtures/typescript-enums/output.ts
+++ b/tests/fixtures/typescript-enums/output.ts
@@ -1,4 +1,4 @@
-import { $ } from 'datadog:privacy-helpers';
+import { $ } from 'datadog:privacy-helpers.mjs';
 const D = $([
   'Number Three',
   'Number One',

--- a/tests/fixtures/typescript-inheritance/output.ts
+++ b/tests/fixtures/typescript-inheritance/output.ts
@@ -1,4 +1,4 @@
-import { $ } from 'datadog:privacy-helpers';
+import { $ } from 'datadog:privacy-helpers.mjs';
 const D = $([
   'SpecificNode',
   'pattern',

--- a/tests/fixtures/typescript-namespaces/output.ts
+++ b/tests/fixtures/typescript-namespaces/output.ts
@@ -1,4 +1,4 @@
-import { $ } from 'datadog:privacy-helpers';
+import { $ } from 'datadog:privacy-helpers.mjs';
 const D = $([
   'betelgeuse',
   'cassiopeia',

--- a/tests/instrumentation-test-plugin/src/core/constants.ts
+++ b/tests/instrumentation-test-plugin/src/core/constants.ts
@@ -1,1 +1,2 @@
-export const PRIVACY_HELPERS_MODULE_ID = '\0datadog:privacy-helpers';
+export const PRIVACY_HELPERS_MODULE_CJS_ID = '\0datadog:privacy-helpers.cjs';
+export const PRIVACY_HELPERS_MODULE_ESM_ID = '\0datadog:privacy-helpers.mjs';

--- a/tests/instrumentation-test-plugin/src/core/options.ts
+++ b/tests/instrumentation-test-plugin/src/core/options.ts
@@ -2,7 +2,10 @@ import type { FilterPattern } from 'unplugin';
 
 import type { InstrumentationOptions } from '@datadog/js-instrumentation-wasm';
 
-import { PRIVACY_HELPERS_MODULE_ID } from './constants';
+import {
+  PRIVACY_HELPERS_MODULE_CJS_ID,
+  PRIVACY_HELPERS_MODULE_ESM_ID,
+} from './constants';
 
 export type PluginOptions = InstrumentationOptions & {
   exclude: FilterPattern;
@@ -25,7 +28,8 @@ export const defaultPluginOptions: PluginOptions = {
   privacy: {
     addToDictionaryHelper: {
       import: {
-        module: PRIVACY_HELPERS_MODULE_ID,
+        cjsModule: PRIVACY_HELPERS_MODULE_CJS_ID,
+        esmModule: PRIVACY_HELPERS_MODULE_ESM_ID,
         func: '$',
       }
     },

--- a/tests/instrumentation-test-plugin/src/core/unplugin.ts
+++ b/tests/instrumentation-test-plugin/src/core/unplugin.ts
@@ -2,13 +2,17 @@ import { createFilter } from '@rollup/pluginutils';
 import { createUnplugin, type UnpluginFactory } from 'unplugin';
 
 import {
+  ImportPrivacyHelperSource,
   instrument,
   type InstrumentationOptions
 } from '@datadog/js-instrumentation-wasm';
 
 import helpers from './generated/privacy-helpers.js-txt';
 
-import { PRIVACY_HELPERS_MODULE_ID } from './constants';
+import {
+  PRIVACY_HELPERS_MODULE_CJS_ID,
+  PRIVACY_HELPERS_MODULE_ESM_ID,
+} from './constants';
 import { defaultPluginOptions, PluginOptions } from './options';
 
 type UnpluginOptions = PluginOptions | undefined;
@@ -21,12 +25,32 @@ function buildInstrumentationOptions(
     options.privacy = options.privacy ?? {};
     options.privacy.addToDictionaryHelper = {
       import: {
-        module: PRIVACY_HELPERS_MODULE_ID,
+        cjsModule: PRIVACY_HELPERS_MODULE_CJS_ID,
+        esmModule: PRIVACY_HELPERS_MODULE_ESM_ID,
         func: '$',
       }
     };
   }
   return options;
+}
+
+function getHelperModuleNames(
+  options: InstrumentationOptions
+): { cjsModule: string, esmModule: string } {
+  const addToDictionaryHelper = options?.privacy?.addToDictionaryHelper ?? {};
+  if (!('import' in addToDictionaryHelper)) {
+    // We're using an expression-style helper. Use the default module names, although we
+    // won't ever actually load or resolve them.
+    return {
+      cjsModule: PRIVACY_HELPERS_MODULE_CJS_ID,
+      esmModule: PRIVACY_HELPERS_MODULE_ESM_ID
+    };
+  }
+  const importHelper = addToDictionaryHelper as ImportPrivacyHelperSource;
+  return {
+    cjsModule: importHelper.import.cjsModule,
+    esmModule: importHelper.import.esmModule,
+  };
 }
 
 export const unpluginFactory: UnpluginFactory<UnpluginOptions> = options => {
@@ -39,12 +63,13 @@ export const unpluginFactory: UnpluginFactory<UnpluginOptions> = options => {
     pluginOptions.include,
     pluginOptions.exclude
   );
+  const { cjsModule, esmModule } = getHelperModuleNames(instrumentationOptions);
   return {
     name: 'instrumentation-test-plugin',
 
     resolveId(source) {
-      if (source === PRIVACY_HELPERS_MODULE_ID) {
-        return { id: PRIVACY_HELPERS_MODULE_ID };
+      if (source === cjsModule || source === esmModule) {
+        return { id: source };
       }
       return null;
     },
@@ -53,20 +78,34 @@ export const unpluginFactory: UnpluginFactory<UnpluginOptions> = options => {
       order: 'pre',
 
       filter: {
-        id: { include: new RegExp(`^${PRIVACY_HELPERS_MODULE_ID}$`) },
+        id: {
+          include: new RegExp(`^(?:${cjsModule})|(?:${esmModule})$`)
+        },
       },
 
       handler(id) {
-        if (id !== PRIVACY_HELPERS_MODULE_ID) {
-          return null;
+        if (id === cjsModule || id === esmModule) {
+          return { code: helpers };
         }
-        return {
-          code: helpers,
-        };
+        return null;
       },
     },
 
     transformInclude(id) {
+      // Check for a literal match for our helpers.
+      if (id === cjsModule || id === esmModule) {
+        return false;
+      }
+
+      // Check for a URI ending with an encoded version of our helpers. (This is how
+      // webpack does things.)
+      const decodedId = decodeURIComponent(id);
+      if (decodedId.endsWith(cjsModule) || decodedId.endsWith(esmModule)) {
+        return false;
+      }
+
+      // We're not dealing with our helpers; fall back to the filter specified in the
+      // options.
       return instrumentationFilter(id);
     },
 

--- a/tests/instrumentation-test-plugin/yarn.lock
+++ b/tests/instrumentation-test-plugin/yarn.lock
@@ -150,8 +150,8 @@ __metadata:
 
 "@datadog/js-instrumentation-wasm@file:../../artifacts/@datadog-js-instrumentation-wasm.tgz::locator=%40datadog%2Finstrumentation-test-plugin%40workspace%3A.":
   version: 0.9.4
-  resolution: "@datadog/js-instrumentation-wasm@file:../../artifacts/@datadog-js-instrumentation-wasm.tgz#../../artifacts/@datadog-js-instrumentation-wasm.tgz::hash=157784&locator=%40datadog%2Finstrumentation-test-plugin%40workspace%3A."
-  checksum: 10c0/f8dc0b4f1697bc10fa81735dac3ae096e7996a17e560e6dd6bab2e974972491805844cd45eb7d5f0392b209ae09ece65022f6712497cf08223b626dabc34465b
+  resolution: "@datadog/js-instrumentation-wasm@file:../../artifacts/@datadog-js-instrumentation-wasm.tgz#../../artifacts/@datadog-js-instrumentation-wasm.tgz::hash=f9f73a&locator=%40datadog%2Finstrumentation-test-plugin%40workspace%3A."
+  checksum: 10c0/7737d5dfb10d815adf58846d73556343bd4e6e902f33fa291be7532836a32b0e7050ed86c87f82b118a083c637c42d976ef1a187212363dfd181dec6797aa55e
   languageName: node
   linkType: hard
 

--- a/tests/integration/esbuild/yarn.lock
+++ b/tests/integration/esbuild/yarn.lock
@@ -93,7 +93,7 @@ __metadata:
 
 "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::locator=esbuild-project%40workspace%3A.":
   version: 0.1
-  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=dc99fd&locator=esbuild-project%40workspace%3A."
+  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=e39de8&locator=esbuild-project%40workspace%3A."
   dependencies:
     unplugin: "npm:^2.3.4"
   peerDependencies:
@@ -119,7 +119,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/a217878674ff4bdf36cf9a452511071a03f28ef3b334ee51bbae248aa7d1a6d8358e6b1efbe35eebfbc11828e2768fe4c207f4f6c8a850e709d3c82ca7dd65fb
+  checksum: 10c0/2544f01e2aa7904c109fa91695e639da85f31edf924350a2b941c6b102b47b1cf9408eebd8fe2561be9e41e0a2281065bc3330927d06e2b8d3ca71267cf8f5ed
   languageName: node
   linkType: hard
 

--- a/tests/integration/vite-with-yarn-pnp/yarn.lock
+++ b/tests/integration/vite-with-yarn-pnp/yarn.lock
@@ -282,7 +282,7 @@ __metadata:
 
 "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::locator=vite-project%40workspace%3A.":
   version: 0.1
-  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=dc99fd&locator=vite-project%40workspace%3A."
+  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=e39de8&locator=vite-project%40workspace%3A."
   dependencies:
     unplugin: "npm:^2.3.4"
   peerDependencies:
@@ -308,7 +308,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/a217878674ff4bdf36cf9a452511071a03f28ef3b334ee51bbae248aa7d1a6d8358e6b1efbe35eebfbc11828e2768fe4c207f4f6c8a850e709d3c82ca7dd65fb
+  checksum: 10c0/2544f01e2aa7904c109fa91695e639da85f31edf924350a2b941c6b102b47b1cf9408eebd8fe2561be9e41e0a2281065bc3330927d06e2b8d3ca71267cf8f5ed
   languageName: node
   linkType: hard
 

--- a/tests/integration/vite/yarn.lock
+++ b/tests/integration/vite/yarn.lock
@@ -282,7 +282,7 @@ __metadata:
 
 "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::locator=vite-project%40workspace%3A.":
   version: 0.1
-  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=dc99fd&locator=vite-project%40workspace%3A."
+  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=e39de8&locator=vite-project%40workspace%3A."
   dependencies:
     unplugin: "npm:^2.3.4"
   peerDependencies:
@@ -308,7 +308,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/a217878674ff4bdf36cf9a452511071a03f28ef3b334ee51bbae248aa7d1a6d8358e6b1efbe35eebfbc11828e2768fe4c207f4f6c8a850e709d3c82ca7dd65fb
+  checksum: 10c0/2544f01e2aa7904c109fa91695e639da85f31edf924350a2b941c6b102b47b1cf9408eebd8fe2561be9e41e0a2281065bc3330927d06e2b8d3ca71267cf8f5ed
   languageName: node
   linkType: hard
 

--- a/tests/integration/webpack/yarn.lock
+++ b/tests/integration/webpack/yarn.lock
@@ -93,7 +93,7 @@ __metadata:
 
 "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::locator=webpack-react-typescript-example%40workspace%3A.":
   version: 0.1
-  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=dc99fd&locator=webpack-react-typescript-example%40workspace%3A."
+  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=e39de8&locator=webpack-react-typescript-example%40workspace%3A."
   dependencies:
     unplugin: "npm:^2.3.4"
   peerDependencies:
@@ -119,7 +119,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/a217878674ff4bdf36cf9a452511071a03f28ef3b334ee51bbae248aa7d1a6d8358e6b1efbe35eebfbc11828e2768fe4c207f4f6c8a850e709d3c82ca7dd65fb
+  checksum: 10c0/2544f01e2aa7904c109fa91695e639da85f31edf924350a2b941c6b102b47b1cf9408eebd8fe2561be9e41e0a2281065bc3330927d06e2b8d3ca71267cf8f5ed
   languageName: node
   linkType: hard
 

--- a/tests/unit/__snapshots__/index.test.ts.snap
+++ b/tests/unit/__snapshots__/index.test.ts.snap
@@ -24,6 +24,16 @@ foo({
 "
 `;
 
+exports[`should be able to set a custom expression addToDictionary helper > for commonjs-require 1`] = `
+"const $ = (v) => console.log(v);
+const D = $([
+  'test',
+]);
+const foo = require('foo-module');
+foo(D[0]);
+"
+`;
+
 exports[`should be able to set a custom expression addToDictionary helper > for conflict 1`] = `
 "const B = (v) => console.log(v);
 const A = B([
@@ -533,7 +543,7 @@ declare let baz: 'unwanted_declared_var_type_1';
 `;
 
 exports[`should be able to set a custom imported addToDictionary helper > for common-cases 1`] = `
-"import { addToDictionary as $ } from '@custom/helpers';
+"import { addToDictionary as $ } from '@custom/helpers.mjs';
 const D = $([
   "some string",
   \`something\`,
@@ -556,8 +566,18 @@ foo({
 "
 `;
 
+exports[`should be able to set a custom imported addToDictionary helper > for commonjs-require 1`] = `
+"const { addToDictionary: $ } = require('@custom/helpers.cjs');
+const D = $([
+  'test',
+]);
+const foo = require('foo-module');
+foo(D[0]);
+"
+`;
+
 exports[`should be able to set a custom imported addToDictionary helper > for conflict 1`] = `
-"import { addToDictionary as B } from '@custom/helpers';
+"import { addToDictionary as B } from '@custom/helpers.mjs';
 const A = B([
   "test",
 ]);
@@ -569,7 +589,7 @@ console.log(/* (attached comment) */ A[0]);
 `;
 
 exports[`should be able to set a custom imported addToDictionary helper > for jsx 1`] = `
-"import { addToDictionary as $ } from '@custom/helpers';
+"import { addToDictionary as $ } from '@custom/helpers.mjs';
 const D = $([
   "Escape special characters with the \\"\\\\\\" character.",
   "Text content. With more than one line. And another.",
@@ -645,7 +665,7 @@ c-9.1,9.1-22.6,13.7-40.3,13.7c-4.6,0-6.9,4-6.9,8V140z"
 `;
 
 exports[`should be able to set a custom imported addToDictionary helper > for reference-size 1`] = `
-"import { addToDictionary as $ } from '@custom/helpers';
+"import { addToDictionary as $ } from '@custom/helpers.mjs';
 const D = $([
   "abcd",
   \`abcdefghi\`,
@@ -704,7 +724,7 @@ const empty6 = foo(D[8], 0, 1, 2);
 `;
 
 exports[`should be able to set a custom imported addToDictionary helper > for regular-expressions 1`] = `
-"import { addToDictionary as $ } from '@custom/helpers';
+"import { addToDictionary as $ } from '@custom/helpers.mjs';
 const D = $([
   \`"\`,
 ]);
@@ -718,7 +738,7 @@ const addQuotes = (string, hasQuotes) =>
 `;
 
 exports[`should be able to set a custom imported addToDictionary helper > for string-literals 1`] = `
-"import { addToDictionary as $ } from '@custom/helpers';
+"import { addToDictionary as $ } from '@custom/helpers.mjs';
 const D = $([
   "appendix",
   "gem\`'\\"\\u{6F}",
@@ -778,7 +798,7 @@ const reuse4 = [...D[4]];
 `;
 
 exports[`should be able to set a custom imported addToDictionary helper > for switch-statements 1`] = `
-"import { addToDictionary as $ } from '@custom/helpers';
+"import { addToDictionary as $ } from '@custom/helpers.mjs';
 const D = $([
   'francis',
   'result',
@@ -820,7 +840,7 @@ export const foo = (value) => {
 `;
 
 exports[`should be able to set a custom imported addToDictionary helper > for tagged-templates-only 1`] = `
-"import { addToDictionary as $ } from '@custom/helpers';
+"import { addToDictionary as $ } from '@custom/helpers.mjs';
 const D = $([
   $\`bar\${0}\`,
 ]);
@@ -830,7 +850,7 @@ console.log(foo(D[0], 1000))
 `;
 
 exports[`should be able to set a custom imported addToDictionary helper > for templates 1`] = `
-"import { addToDictionary as $ } from '@custom/helpers';
+"import { addToDictionary as $ } from '@custom/helpers.mjs';
 const D = $([
   \`\\\`'"\\u{6F}\`,
   \`abc\\r\\n\\t123\`,
@@ -897,7 +917,7 @@ const reuse4 = foo(D[18], foo(D[19], bar));
 `;
 
 exports[`should be able to set a custom imported addToDictionary helper > for ternary-expressions 1`] = `
-"import { addToDictionary as $ } from '@custom/helpers';
+"import { addToDictionary as $ } from '@custom/helpers.mjs';
 const D = $([
   'katherine',
   "charles",
@@ -928,7 +948,7 @@ export const leopold = { [D[7]]: D[8] } ? { [D[2]]: D[12] } : { 'quinn': D[3] };
 `;
 
 exports[`should be able to set a custom imported addToDictionary helper > for trivial 1`] = `
-"import { addToDictionary as $ } from '@custom/helpers';
+"import { addToDictionary as $ } from '@custom/helpers.mjs';
 const D = $([
   "test",
 ]);
@@ -938,7 +958,7 @@ console.log(/* (attached comment) */ D[0]);
 `;
 
 exports[`should be able to set a custom imported addToDictionary helper > for typescript-enums 1`] = `
-"import { addToDictionary as $ } from '@custom/helpers';
+"import { addToDictionary as $ } from '@custom/helpers.mjs';
 const D = $([
   'Number Three',
   'Number One',
@@ -973,7 +993,7 @@ const enum ArabicNumbers {
 `;
 
 exports[`should be able to set a custom imported addToDictionary helper > for typescript-inheritance 1`] = `
-"import { addToDictionary as $ } from '@custom/helpers';
+"import { addToDictionary as $ } from '@custom/helpers.mjs';
 const D = $([
   'SpecificNode',
   'pattern',
@@ -991,7 +1011,7 @@ export class SpecificNode
 `;
 
 exports[`should be able to set a custom imported addToDictionary helper > for typescript-namespaces 1`] = `
-"import { addToDictionary as $ } from '@custom/helpers';
+"import { addToDictionary as $ } from '@custom/helpers.mjs';
 const D = $([
   'betelgeuse',
   'cassiopeia',
@@ -1065,7 +1085,7 @@ declare let baz: 'unwanted_declared_var_type_1';
 `;
 
 exports[`the CJS version should transform code correctly > for common-cases 1`] = `
-"import { $ } from ' datadog:privacy-helpers';
+"import { $ } from ' datadog:privacy-helpers.mjs';
 const D = $([
   "some string",
   \`something\`,
@@ -1088,8 +1108,18 @@ foo({
 "
 `;
 
+exports[`the CJS version should transform code correctly > for commonjs-require 1`] = `
+"const { $ } = require(' datadog:privacy-helpers.cjs');
+const D = $([
+  'test',
+]);
+const foo = require('foo-module');
+foo(D[0]);
+"
+`;
+
 exports[`the CJS version should transform code correctly > for conflict 1`] = `
-"import { $ as B } from ' datadog:privacy-helpers';
+"import { $ as B } from ' datadog:privacy-helpers.mjs';
 const A = B([
   "test",
 ]);
@@ -1101,7 +1131,7 @@ console.log(/* (attached comment) */ A[0]);
 `;
 
 exports[`the CJS version should transform code correctly > for jsx 1`] = `
-"import { $ } from ' datadog:privacy-helpers';
+"import { $ } from ' datadog:privacy-helpers.mjs';
 const D = $([
   "Escape special characters with the \\"\\\\\\" character.",
   "Text content. With more than one line. And another.",
@@ -1177,7 +1207,7 @@ c-9.1,9.1-22.6,13.7-40.3,13.7c-4.6,0-6.9,4-6.9,8V140z"
 `;
 
 exports[`the CJS version should transform code correctly > for reference-size 1`] = `
-"import { $ } from ' datadog:privacy-helpers';
+"import { $ } from ' datadog:privacy-helpers.mjs';
 const D = $([
   "abcd",
   \`abcdefghi\`,
@@ -1236,7 +1266,7 @@ const empty6 = foo(D[8], 0, 1, 2);
 `;
 
 exports[`the CJS version should transform code correctly > for regular-expressions 1`] = `
-"import { $ } from ' datadog:privacy-helpers';
+"import { $ } from ' datadog:privacy-helpers.mjs';
 const D = $([
   \`"\`,
 ]);
@@ -1250,7 +1280,7 @@ const addQuotes = (string, hasQuotes) =>
 `;
 
 exports[`the CJS version should transform code correctly > for string-literals 1`] = `
-"import { $ } from ' datadog:privacy-helpers';
+"import { $ } from ' datadog:privacy-helpers.mjs';
 const D = $([
   "appendix",
   "gem\`'\\"\\u{6F}",
@@ -1310,7 +1340,7 @@ const reuse4 = [...D[4]];
 `;
 
 exports[`the CJS version should transform code correctly > for switch-statements 1`] = `
-"import { $ } from ' datadog:privacy-helpers';
+"import { $ } from ' datadog:privacy-helpers.mjs';
 const D = $([
   'francis',
   'result',
@@ -1352,7 +1382,7 @@ export const foo = (value) => {
 `;
 
 exports[`the CJS version should transform code correctly > for tagged-templates-only 1`] = `
-"import { $ } from ' datadog:privacy-helpers';
+"import { $ } from ' datadog:privacy-helpers.mjs';
 const D = $([
   $\`bar\${0}\`,
 ]);
@@ -1362,7 +1392,7 @@ console.log(foo(D[0], 1000))
 `;
 
 exports[`the CJS version should transform code correctly > for templates 1`] = `
-"import { $ } from ' datadog:privacy-helpers';
+"import { $ } from ' datadog:privacy-helpers.mjs';
 const D = $([
   \`\\\`'"\\u{6F}\`,
   \`abc\\r\\n\\t123\`,
@@ -1429,7 +1459,7 @@ const reuse4 = foo(D[18], foo(D[19], bar));
 `;
 
 exports[`the CJS version should transform code correctly > for ternary-expressions 1`] = `
-"import { $ } from ' datadog:privacy-helpers';
+"import { $ } from ' datadog:privacy-helpers.mjs';
 const D = $([
   'katherine',
   "charles",
@@ -1460,7 +1490,7 @@ export const leopold = { [D[7]]: D[8] } ? { [D[2]]: D[12] } : { 'quinn': D[3] };
 `;
 
 exports[`the CJS version should transform code correctly > for trivial 1`] = `
-"import { $ } from ' datadog:privacy-helpers';
+"import { $ } from ' datadog:privacy-helpers.mjs';
 const D = $([
   "test",
 ]);
@@ -1470,7 +1500,7 @@ console.log(/* (attached comment) */ D[0]);
 `;
 
 exports[`the CJS version should transform code correctly > for typescript-enums 1`] = `
-"import { $ } from ' datadog:privacy-helpers';
+"import { $ } from ' datadog:privacy-helpers.mjs';
 const D = $([
   'Number Three',
   'Number One',
@@ -1505,7 +1535,7 @@ const enum ArabicNumbers {
 `;
 
 exports[`the CJS version should transform code correctly > for typescript-inheritance 1`] = `
-"import { $ } from ' datadog:privacy-helpers';
+"import { $ } from ' datadog:privacy-helpers.mjs';
 const D = $([
   'SpecificNode',
   'pattern',
@@ -1523,7 +1553,7 @@ export class SpecificNode
 `;
 
 exports[`the CJS version should transform code correctly > for typescript-namespaces 1`] = `
-"import { $ } from ' datadog:privacy-helpers';
+"import { $ } from ' datadog:privacy-helpers.mjs';
 const D = $([
   'betelgeuse',
   'cassiopeia',
@@ -1597,7 +1627,7 @@ declare let baz: 'unwanted_declared_var_type_1';
 `;
 
 exports[`the ESM version should transform code correctly > for common-cases 1`] = `
-"import { $ } from ' datadog:privacy-helpers';
+"import { $ } from ' datadog:privacy-helpers.mjs';
 const D = $([
   "some string",
   \`something\`,
@@ -1620,8 +1650,18 @@ foo({
 "
 `;
 
+exports[`the ESM version should transform code correctly > for commonjs-require 1`] = `
+"const { $ } = require(' datadog:privacy-helpers.cjs');
+const D = $([
+  'test',
+]);
+const foo = require('foo-module');
+foo(D[0]);
+"
+`;
+
 exports[`the ESM version should transform code correctly > for conflict 1`] = `
-"import { $ as B } from ' datadog:privacy-helpers';
+"import { $ as B } from ' datadog:privacy-helpers.mjs';
 const A = B([
   "test",
 ]);
@@ -1633,7 +1673,7 @@ console.log(/* (attached comment) */ A[0]);
 `;
 
 exports[`the ESM version should transform code correctly > for jsx 1`] = `
-"import { $ } from ' datadog:privacy-helpers';
+"import { $ } from ' datadog:privacy-helpers.mjs';
 const D = $([
   "Escape special characters with the \\"\\\\\\" character.",
   "Text content. With more than one line. And another.",
@@ -1709,7 +1749,7 @@ c-9.1,9.1-22.6,13.7-40.3,13.7c-4.6,0-6.9,4-6.9,8V140z"
 `;
 
 exports[`the ESM version should transform code correctly > for reference-size 1`] = `
-"import { $ } from ' datadog:privacy-helpers';
+"import { $ } from ' datadog:privacy-helpers.mjs';
 const D = $([
   "abcd",
   \`abcdefghi\`,
@@ -1768,7 +1808,7 @@ const empty6 = foo(D[8], 0, 1, 2);
 `;
 
 exports[`the ESM version should transform code correctly > for regular-expressions 1`] = `
-"import { $ } from ' datadog:privacy-helpers';
+"import { $ } from ' datadog:privacy-helpers.mjs';
 const D = $([
   \`"\`,
 ]);
@@ -1782,7 +1822,7 @@ const addQuotes = (string, hasQuotes) =>
 `;
 
 exports[`the ESM version should transform code correctly > for string-literals 1`] = `
-"import { $ } from ' datadog:privacy-helpers';
+"import { $ } from ' datadog:privacy-helpers.mjs';
 const D = $([
   "appendix",
   "gem\`'\\"\\u{6F}",
@@ -1842,7 +1882,7 @@ const reuse4 = [...D[4]];
 `;
 
 exports[`the ESM version should transform code correctly > for switch-statements 1`] = `
-"import { $ } from ' datadog:privacy-helpers';
+"import { $ } from ' datadog:privacy-helpers.mjs';
 const D = $([
   'francis',
   'result',
@@ -1884,7 +1924,7 @@ export const foo = (value) => {
 `;
 
 exports[`the ESM version should transform code correctly > for tagged-templates-only 1`] = `
-"import { $ } from ' datadog:privacy-helpers';
+"import { $ } from ' datadog:privacy-helpers.mjs';
 const D = $([
   $\`bar\${0}\`,
 ]);
@@ -1894,7 +1934,7 @@ console.log(foo(D[0], 1000))
 `;
 
 exports[`the ESM version should transform code correctly > for templates 1`] = `
-"import { $ } from ' datadog:privacy-helpers';
+"import { $ } from ' datadog:privacy-helpers.mjs';
 const D = $([
   \`\\\`'"\\u{6F}\`,
   \`abc\\r\\n\\t123\`,
@@ -1961,7 +2001,7 @@ const reuse4 = foo(D[18], foo(D[19], bar));
 `;
 
 exports[`the ESM version should transform code correctly > for ternary-expressions 1`] = `
-"import { $ } from ' datadog:privacy-helpers';
+"import { $ } from ' datadog:privacy-helpers.mjs';
 const D = $([
   'katherine',
   "charles",
@@ -1992,7 +2032,7 @@ export const leopold = { [D[7]]: D[8] } ? { [D[2]]: D[12] } : { 'quinn': D[3] };
 `;
 
 exports[`the ESM version should transform code correctly > for trivial 1`] = `
-"import { $ } from ' datadog:privacy-helpers';
+"import { $ } from ' datadog:privacy-helpers.mjs';
 const D = $([
   "test",
 ]);
@@ -2002,7 +2042,7 @@ console.log(/* (attached comment) */ D[0]);
 `;
 
 exports[`the ESM version should transform code correctly > for typescript-enums 1`] = `
-"import { $ } from ' datadog:privacy-helpers';
+"import { $ } from ' datadog:privacy-helpers.mjs';
 const D = $([
   'Number Three',
   'Number One',
@@ -2037,7 +2077,7 @@ const enum ArabicNumbers {
 `;
 
 exports[`the ESM version should transform code correctly > for typescript-inheritance 1`] = `
-"import { $ } from ' datadog:privacy-helpers';
+"import { $ } from ' datadog:privacy-helpers.mjs';
 const D = $([
   'SpecificNode',
   'pattern',
@@ -2055,7 +2095,7 @@ export class SpecificNode
 `;
 
 exports[`the ESM version should transform code correctly > for typescript-namespaces 1`] = `
-"import { $ } from ' datadog:privacy-helpers';
+"import { $ } from ' datadog:privacy-helpers.mjs';
 const D = $([
   'betelgeuse',
   'cassiopeia',

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -44,7 +44,8 @@ describe('should be able to set a custom imported addToDictionary helper', async
     privacy: {
       addToDictionaryHelper: {
         import: {
-          module: '@custom/helpers',
+          cjsModule: '@custom/helpers.cjs',
+          esmModule: '@custom/helpers.mjs',
           func: 'addToDictionary',
         }
       }
@@ -76,4 +77,3 @@ describe('should be able to set a custom expression addToDictionary helper', asy
     });
   });
 });
-

--- a/tests/unit/yarn.lock
+++ b/tests/unit/yarn.lock
@@ -92,7 +92,7 @@ __metadata:
 
 "@datadog/instrumentation-test-plugin@file:../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::locator=%40datadog%2Fjs-instrumentation-wasm-unit-tests%40workspace%3A.":
   version: 0.1
-  resolution: "@datadog/instrumentation-test-plugin@file:../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=dc99fd&locator=%40datadog%2Fjs-instrumentation-wasm-unit-tests%40workspace%3A."
+  resolution: "@datadog/instrumentation-test-plugin@file:../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=e39de8&locator=%40datadog%2Fjs-instrumentation-wasm-unit-tests%40workspace%3A."
   dependencies:
     unplugin: "npm:^2.3.4"
   peerDependencies:
@@ -118,7 +118,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/a217878674ff4bdf36cf9a452511071a03f28ef3b334ee51bbae248aa7d1a6d8358e6b1efbe35eebfbc11828e2768fe4c207f4f6c8a850e709d3c82ca7dd65fb
+  checksum: 10c0/2544f01e2aa7904c109fa91695e639da85f31edf924350a2b941c6b102b47b1cf9408eebd8fe2561be9e41e0a2281065bc3330927d06e2b8d3ca71267cf8f5ed
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

This PR makes it possible to specify separate helper modules for CommonJS modules (i.e., `require()`) and ES modules. This makes it easier to distinguish between the two cases at the loader level and inject different helper module implementations for each situation.

Note that this changes the options accepted by `instrument()` somewhat, since the `module` option has been replaced by `cjsModule` and `esmModule`. (You must provide both, but they don't have to be different, although in practice they should be.)

## How to reproduce and testing

Existing tests are updated; new tests are included.