### PR TITLE
Add support for exclusion directives

### DIFF
--- a/rust/js-instrumentation-shared/src/input_file.rs
+++ b/rust/js-instrumentation-shared/src/input_file.rs
@@ -32,6 +32,13 @@ impl<'a> InputFile<'a> {
         StringInput::new(self.code, self.start_pos, self.end_pos)
     }
 
+    pub fn span(self: &Self) -> Span {
+        Span {
+            lo: self.start_pos,
+            hi: self.end_pos,
+        }
+    }
+
     pub fn may_follow_keyword(self: &mut Self, pos: BytePos) -> bool {
         if pos == self.start_pos {
             return false;

--- a/rust/js-instrumentation-shared/src/parser.rs
+++ b/rust/js-instrumentation-shared/src/parser.rs
@@ -1,3 +1,4 @@
+use swc_common::comments::SingleThreadedComments;
 use swc_ecma_ast::EsVersion::EsNext;
 use swc_ecma_parser::{lexer::Lexer, Parser, StringInput};
 
@@ -5,18 +6,23 @@ use crate::{input_file::InputFile, instrumentation_options::InstrumentationOptio
 
 pub fn build_parser<'a>(
     file: &InputFile<'a>,
+    comments: &'a SingleThreadedComments,
     options: &InstrumentationOptions,
 ) -> Parser<Lexer<'a>> {
-    let lexer = build_lexer(file, options);
+    let lexer = build_lexer(file, comments, options);
     Parser::new_from(lexer)
 }
 
-fn build_lexer<'a>(file: &InputFile<'a>, options: &InstrumentationOptions) -> Lexer<'a> {
+fn build_lexer<'a>(
+    file: &InputFile<'a>,
+    comments: &'a SingleThreadedComments,
+    options: &InstrumentationOptions,
+) -> Lexer<'a> {
     let syntax = syntax_for(file.name, options);
     Lexer::new(
         syntax,
         EsNext,
         StringInput::new(file.code, file.start_pos, file.end_pos),
-        None,
+        Some(comments),
     )
 }

--- a/rust/js-instrumentation-transform/src/directives/directive_set.rs
+++ b/rust/js-instrumentation-transform/src/directives/directive_set.rs
@@ -1,0 +1,213 @@
+use js_instrumentation_shared::InputFile;
+use swc_common::{
+    comments::{Comment, SingleThreadedComments},
+    BytePos, Span,
+};
+
+const PRIVACY_ALLOWLIST_EXCLUDE_BEGIN_COMMENT: &'static str =
+    "datadog-privacy-allowlist-exclude-begin";
+const PRIVACY_ALLOWLIST_EXCLUDE_END_COMMENT: &'static str = "datadog-privacy-allowlist-exclude-end";
+const PRIVACY_ALLOWLIST_EXCLUDE_FILE_COMMENT: &'static str =
+    "datadog-privacy-allowlist-exclude-file";
+const PRIVACY_ALLOWLIST_EXCLUDE_LINE_COMMENT: &'static str =
+    "datadog-privacy-allowlist-exclude-line";
+const PRIVACY_ALLOWLIST_EXCLUDE_NEXT_LINE_COMMENT: &'static str =
+    "datadog-privacy-allowlist-exclude-next-line";
+
+pub struct DirectiveSet {
+    privacy_allowlist_excluded_file: bool,
+    privacy_allowlist_excluded_spans: Vec<Span>,
+}
+
+impl DirectiveSet {
+    pub fn new(file: &InputFile, comments: &SingleThreadedComments) -> Self {
+        let mut privacy_allowlist_excluded_file = false;
+        let mut privacy_allowlist_excluded_spans: Vec<Span> = Vec::new();
+        let mut exclusion_begin_positions: Vec<BytePos> = Vec::new();
+        let mut exclusion_end_positions: Vec<BytePos> = Vec::new();
+
+        let (leading_comments, trailing_comments) = comments.borrow_all();
+        for (_pos, comments) in leading_comments.iter().chain(trailing_comments.iter()) {
+            for comment in comments {
+                if let Some(span) = parse_privacy_allowlist_excluded_span_directive(file, comment) {
+                    if span == file.span() {
+                        privacy_allowlist_excluded_file = true;
+                    } else {
+                        privacy_allowlist_excluded_spans.push(span);
+                    }
+                } else if let Some(pos) = parse_privacy_allowlist_exclude_begin_directive(comment) {
+                    exclusion_begin_positions.push(pos);
+                } else if let Some(pos) = parse_privacy_allowlist_exclude_end_directive(comment) {
+                    exclusion_end_positions.push(pos);
+                }
+            }
+        }
+
+        add_spans_for_exclusion_begin_and_end_positions(
+            file,
+            &mut privacy_allowlist_excluded_spans,
+            exclusion_begin_positions,
+            exclusion_end_positions,
+        );
+
+        return DirectiveSet {
+            privacy_allowlist_excluded_file,
+            privacy_allowlist_excluded_spans,
+        };
+    }
+
+    pub fn excludes_span_from_privacy_allowlist(self: &Self, span: &Span) -> bool {
+        if self.privacy_allowlist_excluded_file {
+            return true;
+        }
+        for excluded_span in &self.privacy_allowlist_excluded_spans {
+            if spans_intersect(span, &excluded_span) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+fn parse_privacy_allowlist_excluded_span_directive(
+    file: &InputFile,
+    comment: &Comment,
+) -> Option<Span> {
+    let text = comment.text.as_str().trim();
+    if text == PRIVACY_ALLOWLIST_EXCLUDE_FILE_COMMENT {
+        Some(Span {
+            lo: file.start_pos,
+            hi: file.end_pos,
+        })
+    } else if text == PRIVACY_ALLOWLIST_EXCLUDE_LINE_COMMENT {
+        bounds_of_lines_intersecting_span(comment.span, file)
+    } else if text == PRIVACY_ALLOWLIST_EXCLUDE_NEXT_LINE_COMMENT {
+        bounds_of_line_after_pos(comment.span.hi, file)
+    } else {
+        None
+    }
+}
+
+fn parse_privacy_allowlist_exclude_begin_directive(comment: &Comment) -> Option<BytePos> {
+    let text = comment.text.as_str().trim();
+    if text == PRIVACY_ALLOWLIST_EXCLUDE_BEGIN_COMMENT {
+        Some(comment.span.lo)
+    } else {
+        None
+    }
+}
+
+fn parse_privacy_allowlist_exclude_end_directive(comment: &Comment) -> Option<BytePos> {
+    let text = comment.text.as_str().trim();
+    if text == PRIVACY_ALLOWLIST_EXCLUDE_END_COMMENT {
+        Some(comment.span.hi)
+    } else {
+        None
+    }
+}
+
+fn add_spans_for_exclusion_begin_and_end_positions(
+    file: &InputFile,
+    privacy_allowlist_excluded_spans: &mut Vec<Span>,
+    mut exclusion_begin_positions: Vec<BytePos>,
+    mut exclusion_end_positions: Vec<BytePos>,
+) {
+    exclusion_begin_positions.sort_unstable();
+    exclusion_end_positions.sort_unstable();
+
+    // Convert begin/end directives into spans.
+    let mut exclusion_end_iter = exclusion_end_positions.into_iter();
+    let mut last_end_pos: Option<BytePos> = None;
+    for begin_pos in exclusion_begin_positions {
+        // If there are other begin directives between a begin directive and the next end
+        // directive, ignore them.
+        match &last_end_pos {
+            Some(last_end_pos) if begin_pos < *last_end_pos => continue,
+            _ => {}
+        }
+
+        // Find the next end directive that follows this begin directive.
+        let mut end_pos: Option<BytePos>;
+        loop {
+            end_pos = exclusion_end_iter.next();
+            match end_pos {
+                Some(end_pos) if end_pos <= begin_pos => continue,
+                _ => break,
+            }
+        }
+
+        // If this begin directive has a corresponding end directive, generate a span between
+        // the two directives. Otherwise, generate a span ranging from the begin directive to
+        // the end of the file.
+        match end_pos {
+            Some(end_pos) => {
+                last_end_pos = Some(end_pos);
+                privacy_allowlist_excluded_spans.push(Span {
+                    lo: begin_pos,
+                    hi: end_pos,
+                });
+            }
+            None => {
+                last_end_pos = Some(file.end_pos);
+                privacy_allowlist_excluded_spans.push(Span {
+                    lo: begin_pos,
+                    hi: file.end_pos,
+                });
+            }
+        }
+    }
+
+    privacy_allowlist_excluded_spans.sort_unstable();
+}
+
+fn bounds_of_lines_intersecting_span(span: Span, file: &InputFile) -> Option<Span> {
+    let lo_span = bounds_of_line_containing_pos(span.lo, file);
+    let hi_span = bounds_of_line_containing_pos(span.hi, file);
+    match (lo_span, hi_span) {
+        (Some(lo_span), Some(hi_span)) => Some(Span {
+            lo: lo_span.lo,
+            hi: hi_span.hi,
+        }),
+        (Some(lo_span), None) => Some(Span {
+            lo: lo_span.lo,
+            hi: lo_span.hi,
+        }),
+        (None, Some(hi_span)) => Some(Span {
+            lo: hi_span.lo,
+            hi: hi_span.hi,
+        }),
+        (None, None) => None,
+    }
+}
+
+fn bounds_of_line_containing_pos(pos: BytePos, file: &InputFile) -> Option<Span> {
+    let source_file_and_line = file.map.lookup_line(pos).ok()?;
+    let line_bounds = source_file_and_line
+        .sf
+        .line_bounds(source_file_and_line.line);
+    Some(Span {
+        lo: line_bounds.0,
+        hi: line_bounds.1,
+    })
+}
+
+fn bounds_of_line_after_pos(pos: BytePos, file: &InputFile) -> Option<Span> {
+    let source_file_and_line = file.map.lookup_line(pos).ok()?;
+    let line_bounds = source_file_and_line
+        .sf
+        .line_bounds(source_file_and_line.line + 1);
+    Some(Span {
+        lo: line_bounds.0,
+        hi: line_bounds.1,
+    })
+}
+
+fn spans_intersect(a: &Span, b: &Span) -> bool {
+    if a.hi <= b.lo {
+        return false;
+    }
+    if b.hi <= a.lo {
+        return false;
+    }
+    return true;
+}

--- a/rust/js-instrumentation-transform/src/directives/mod.rs
+++ b/rust/js-instrumentation-transform/src/directives/mod.rs
@@ -1,0 +1,2 @@
+mod directive_set;
+pub use directive_set::DirectiveSet;

--- a/rust/js-instrumentation-transform/src/lib.rs
+++ b/rust/js-instrumentation-transform/src/lib.rs
@@ -1,4 +1,5 @@
 mod dictionary;
+mod directives;
 mod features;
 mod identifiers;
 mod instrumentation_transform;

--- a/tests/fixtures/excluded-file/input.js
+++ b/tests/fixtures/excluded-file/input.js
@@ -1,0 +1,7 @@
+// datadog-privacy-allowlist-exclude-file
+console.log(
+  "Should",
+  'not',
+  `be`,
+  "allowlisted"
+);

--- a/tests/fixtures/excluded-file/output.js
+++ b/tests/fixtures/excluded-file/output.js
@@ -1,0 +1,7 @@
+// datadog-privacy-allowlist-exclude-file
+console.log(
+  "Should",
+  'not',
+  `be`,
+  "allowlisted"
+);

--- a/tests/fixtures/excluded-lines/input.js
+++ b/tests/fixtures/excluded-lines/input.js
@@ -1,0 +1,172 @@
+const tag = () => { };
+
+// Should be able to exclude any kind of string with an exclude-line.
+console.log(
+  'not excluded',
+  "exclude line 1", // datadog-privacy-allowlist-exclude-line
+  'not excluded',
+  'exclude line 2', // datadog-privacy-allowlist-exclude-line
+  'not excluded',
+  `exclude line 3`, // datadog-privacy-allowlist-exclude-line
+  'not excluded',
+  tag`exclude line 4`, // datadog-privacy-allowlist-exclude-line
+  'not excluded',
+);
+
+// Block comments should also work.
+console.log(
+  'not excluded',
+  "block 1", /* datadog-privacy-allowlist-exclude-line */
+  'not excluded',
+  'block 2', /* datadog-privacy-allowlist-exclude-line */
+  'not excluded',
+  `block 3`, /* datadog-privacy-allowlist-exclude-line */
+  'not excluded',
+  tag`block 4`, /* datadog-privacy-allowlist-exclude-line */
+  'not excluded',
+);
+
+// Prefixed block comments should also work.
+console.log(
+  'not excluded',
+  /* datadog-privacy-allowlist-exclude-line */ "prefixed block 1",
+  'not excluded',
+  /* datadog-privacy-allowlist-exclude-line */ 'prefixed block 2',
+  'not excluded',
+  /* datadog-privacy-allowlist-exclude-line */ `prefixed block 3`,
+  'not excluded',
+  /* datadog-privacy-allowlist-exclude-line */ tag`prefixed block 4`,
+  'not excluded',
+);
+
+// Multiline block comments should also work.
+console.log(
+  'not excluded',
+  /*
+   datadog-privacy-allowlist-exclude-line
+   */ "multiline block 1",
+  'not excluded',
+  /*
+   datadog-privacy-allowlist-exclude-line
+   */ 'multiline block 2',
+  'not excluded',
+  /*
+   datadog-privacy-allowlist-exclude-line
+   */ `multiline block 3`,
+  'not excluded',
+  /*
+   datadog-privacy-allowlist-exclude-line
+   */ tag`multiline block 4`,
+  'not excluded',
+);
+
+// Should be able to exclude any kind of string with an exclude-next-line.
+console.log(
+  'not excluded',
+  // datadog-privacy-allowlist-exclude-next-line
+  "exclude next line 1",
+  'not excluded',
+  // datadog-privacy-allowlist-exclude-next-line
+  'exclude next line 2',
+  'not excluded',
+  // datadog-privacy-allowlist-exclude-next-line
+  `exclude next line 3`,
+  'not excluded',
+  // datadog-privacy-allowlist-exclude-next-line
+  tag`exclude next line 4`,
+  'not excluded',
+);
+
+// Block comments should also work for exclude-next-line.
+console.log(
+  'not excluded',
+  /* datadog-privacy-allowlist-exclude-next-line */
+  "exclude next line block 1",
+  'not excluded',
+  /* datadog-privacy-allowlist-exclude-next-line */
+  'exclude next line block 2',
+  'not excluded',
+  /* datadog-privacy-allowlist-exclude-next-line */
+  `exclude next line block 3`,
+  'not excluded',
+  /* datadog-privacy-allowlist-exclude-next-line */
+  tag`exclude next line block 4`,
+  'not excluded',
+);
+
+// Multiline block comments should also work for exclude-next-line.
+console.log(
+  'not excluded',
+  /*
+   datadog-privacy-allowlist-exclude-next-line
+   */
+  "exclude next line multiline block 1",
+  'not excluded',
+  /*
+   datadog-privacy-allowlist-exclude-next-line
+   */
+  'exclude next line multiline block 2',
+  'not excluded',
+  /*
+   datadog-privacy-allowlist-exclude-next-line
+   */
+  `exclude next line multiline block 3`,
+  'not excluded',
+  /*
+   datadog-privacy-allowlist-exclude-next-line
+   */
+  tag`exclude next line multiline block 4`,
+  'not excluded',
+);
+
+// We should be able to exclude a range of lines.
+console.log(
+  'not excluded',
+  // datadog-privacy-allowlist-exclude-begin
+  "exclude range 1",
+  'exclude range 2',
+  `exclude range 3`,
+  tag`exclude range 4`,
+  // datadog-privacy-allowlist-exclude-end
+  'not excluded',
+);
+
+// We should be able to exclude a range of with a block comment.
+console.log(
+  'not excluded',
+  /* datadog-privacy-allowlist-exclude-begin */
+  "exclude range with block comment 1",
+  'exclude range with block comment 2',
+  `exclude range with block comment 3`,
+  tag`exclude range with block comment 4`,
+  /* datadog-privacy-allowlist-exclude-end */
+  'not excluded',
+);
+
+// Extra 'exclude-begin' directives inside an exclusion and 'exclude-end'
+// directives outside of an exclusion should have no effect.
+console.log(
+  'not excluded',
+  // datadog-privacy-allowlist-exclude-end
+  'not excluded',
+  // datadog-privacy-allowlist-exclude-begin
+  "exclude range with extra directives 1",
+  'exclude range with extra directives 2',
+  // datadog-privacy-allowlist-exclude-begin
+  `exclude range with extra directives 3`,
+  tag`exclude range with extra directives 4`,
+  // datadog-privacy-allowlist-exclude-end
+  'not excluded',
+);
+
+// An unterminated 'exclude-begin' should cover the rest of the file. (And extra
+// 'exclude-begins' after that point should be ignored.)
+console.log(
+  'not excluded',
+  /* datadog-privacy-allowlist-exclude-begin */
+  "exclude range with unterminated comment 1",
+  'exclude range with unterminated comment 2',
+  /* datadog-privacy-allowlist-exclude-begin */
+  `exclude range with unterminated comment 3`,
+  tag`exclude range with unterminated comment 4`,
+);

--- a/tests/fixtures/excluded-lines/output.js
+++ b/tests/fixtures/excluded-lines/output.js
@@ -1,0 +1,176 @@
+import { $ } from 'datadog:privacy-helpers.mjs';
+const D = $([
+  'not excluded',
+]);
+const tag = () => { };
+
+// Should be able to exclude any kind of string with an exclude-line.
+console.log(
+  D[0],
+  "exclude line 1", // datadog-privacy-allowlist-exclude-line
+  D[0],
+  'exclude line 2', // datadog-privacy-allowlist-exclude-line
+  D[0],
+  `exclude line 3`, // datadog-privacy-allowlist-exclude-line
+  D[0],
+  tag`exclude line 4`, // datadog-privacy-allowlist-exclude-line
+  D[0],
+);
+
+// Block comments should also work.
+console.log(
+  D[0],
+  "block 1", /* datadog-privacy-allowlist-exclude-line */
+  D[0],
+  'block 2', /* datadog-privacy-allowlist-exclude-line */
+  D[0],
+  `block 3`, /* datadog-privacy-allowlist-exclude-line */
+  D[0],
+  tag`block 4`, /* datadog-privacy-allowlist-exclude-line */
+  D[0],
+);
+
+// Prefixed block comments should also work.
+console.log(
+  D[0],
+  /* datadog-privacy-allowlist-exclude-line */ "prefixed block 1",
+  D[0],
+  /* datadog-privacy-allowlist-exclude-line */ 'prefixed block 2',
+  D[0],
+  /* datadog-privacy-allowlist-exclude-line */ `prefixed block 3`,
+  D[0],
+  /* datadog-privacy-allowlist-exclude-line */ tag`prefixed block 4`,
+  D[0],
+);
+
+// Multiline block comments should also work.
+console.log(
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-line
+   */ "multiline block 1",
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-line
+   */ 'multiline block 2',
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-line
+   */ `multiline block 3`,
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-line
+   */ tag`multiline block 4`,
+  D[0],
+);
+
+// Should be able to exclude any kind of string with an exclude-next-line.
+console.log(
+  D[0],
+  // datadog-privacy-allowlist-exclude-next-line
+  "exclude next line 1",
+  D[0],
+  // datadog-privacy-allowlist-exclude-next-line
+  'exclude next line 2',
+  D[0],
+  // datadog-privacy-allowlist-exclude-next-line
+  `exclude next line 3`,
+  D[0],
+  // datadog-privacy-allowlist-exclude-next-line
+  tag`exclude next line 4`,
+  D[0],
+);
+
+// Block comments should also work for exclude-next-line.
+console.log(
+  D[0],
+  /* datadog-privacy-allowlist-exclude-next-line */
+  "exclude next line block 1",
+  D[0],
+  /* datadog-privacy-allowlist-exclude-next-line */
+  'exclude next line block 2',
+  D[0],
+  /* datadog-privacy-allowlist-exclude-next-line */
+  `exclude next line block 3`,
+  D[0],
+  /* datadog-privacy-allowlist-exclude-next-line */
+  tag`exclude next line block 4`,
+  D[0],
+);
+
+// Multiline block comments should also work for exclude-next-line.
+console.log(
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-next-line
+   */
+  "exclude next line multiline block 1",
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-next-line
+   */
+  'exclude next line multiline block 2',
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-next-line
+   */
+  `exclude next line multiline block 3`,
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-next-line
+   */
+  tag`exclude next line multiline block 4`,
+  D[0],
+);
+
+// We should be able to exclude a range of lines.
+console.log(
+  D[0],
+  // datadog-privacy-allowlist-exclude-begin
+  "exclude range 1",
+  'exclude range 2',
+  `exclude range 3`,
+  tag`exclude range 4`,
+  // datadog-privacy-allowlist-exclude-end
+  D[0],
+);
+
+// We should be able to exclude a range of with a block comment.
+console.log(
+  D[0],
+  /* datadog-privacy-allowlist-exclude-begin */
+  "exclude range with block comment 1",
+  'exclude range with block comment 2',
+  `exclude range with block comment 3`,
+  tag`exclude range with block comment 4`,
+  /* datadog-privacy-allowlist-exclude-end */
+  D[0],
+);
+
+// Extra 'exclude-begin' directives inside an exclusion and 'exclude-end'
+// directives outside of an exclusion should have no effect.
+console.log(
+  D[0],
+  // datadog-privacy-allowlist-exclude-end
+  D[0],
+  // datadog-privacy-allowlist-exclude-begin
+  "exclude range with extra directives 1",
+  'exclude range with extra directives 2',
+  // datadog-privacy-allowlist-exclude-begin
+  `exclude range with extra directives 3`,
+  tag`exclude range with extra directives 4`,
+  // datadog-privacy-allowlist-exclude-end
+  D[0],
+);
+
+// An unterminated 'exclude-begin' should cover the rest of the file. (And extra
+// 'exclude-begins' after that point should be ignored.)
+console.log(
+  D[0],
+  /* datadog-privacy-allowlist-exclude-begin */
+  "exclude range with unterminated comment 1",
+  'exclude range with unterminated comment 2',
+  /* datadog-privacy-allowlist-exclude-begin */
+  `exclude range with unterminated comment 3`,
+  tag`exclude range with unterminated comment 4`,
+);

--- a/tests/instrumentation-test-plugin/yarn.lock
+++ b/tests/instrumentation-test-plugin/yarn.lock
@@ -150,8 +150,8 @@ __metadata:
 
 "@datadog/js-instrumentation-wasm@file:../../artifacts/@datadog-js-instrumentation-wasm.tgz::locator=%40datadog%2Finstrumentation-test-plugin%40workspace%3A.":
   version: 0.9.7
-  resolution: "@datadog/js-instrumentation-wasm@file:../../artifacts/@datadog-js-instrumentation-wasm.tgz#../../artifacts/@datadog-js-instrumentation-wasm.tgz::hash=1693d6&locator=%40datadog%2Finstrumentation-test-plugin%40workspace%3A."
-  checksum: 10c0/60075e90ca324d855143c4c681757b9345494e000ef29cc026acf25c343738bef61c2bbb2aa636f56b687dd59b0ac494be204c05fafe0a7095ed6ee9bee8b851
+  resolution: "@datadog/js-instrumentation-wasm@file:../../artifacts/@datadog-js-instrumentation-wasm.tgz#../../artifacts/@datadog-js-instrumentation-wasm.tgz::hash=2e28fe&locator=%40datadog%2Finstrumentation-test-plugin%40workspace%3A."
+  checksum: 10c0/422c59c64de397b069815612b0dc439e799309897d597b015ea001edef4345ebf2d119f08f5ea1fd861dcc6fc7c3b6a678e9edf5f44cb7c0812c9e1b08d48253
   languageName: node
   linkType: hard
 

--- a/tests/integration/esbuild/yarn.lock
+++ b/tests/integration/esbuild/yarn.lock
@@ -93,7 +93,7 @@ __metadata:
 
 "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::locator=esbuild-project%40workspace%3A.":
   version: 0.1
-  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=c656dd&locator=esbuild-project%40workspace%3A."
+  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=27ecc2&locator=esbuild-project%40workspace%3A."
   dependencies:
     unplugin: "npm:^2.3.4"
   peerDependencies:
@@ -119,7 +119,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/b05233d8cc629bf444e89f68cbb34ec48723a82924da6d2e326d022ce3cca032dec401a12f1b7ac7baa4ce56e43b6c3a4c309e7f8882e0950376eec37aadbd96
+  checksum: 10c0/0f6a6573bd898c3e1ba89b095881c3db01f60d260ce621dd93d326a244e9fc15abce64ff53b154b668dae4d092d1adfc0eecf8cad6419e9ed7aaacd05e0449e9
   languageName: node
   linkType: hard
 

--- a/tests/integration/vite-with-yarn-pnp/yarn.lock
+++ b/tests/integration/vite-with-yarn-pnp/yarn.lock
@@ -282,7 +282,7 @@ __metadata:
 
 "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::locator=vite-project%40workspace%3A.":
   version: 0.1
-  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=c656dd&locator=vite-project%40workspace%3A."
+  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=27ecc2&locator=vite-project%40workspace%3A."
   dependencies:
     unplugin: "npm:^2.3.4"
   peerDependencies:
@@ -308,7 +308,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/b05233d8cc629bf444e89f68cbb34ec48723a82924da6d2e326d022ce3cca032dec401a12f1b7ac7baa4ce56e43b6c3a4c309e7f8882e0950376eec37aadbd96
+  checksum: 10c0/0f6a6573bd898c3e1ba89b095881c3db01f60d260ce621dd93d326a244e9fc15abce64ff53b154b668dae4d092d1adfc0eecf8cad6419e9ed7aaacd05e0449e9
   languageName: node
   linkType: hard
 

--- a/tests/integration/vite/yarn.lock
+++ b/tests/integration/vite/yarn.lock
@@ -282,7 +282,7 @@ __metadata:
 
 "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::locator=vite-project%40workspace%3A.":
   version: 0.1
-  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=c656dd&locator=vite-project%40workspace%3A."
+  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=27ecc2&locator=vite-project%40workspace%3A."
   dependencies:
     unplugin: "npm:^2.3.4"
   peerDependencies:
@@ -308,7 +308,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/b05233d8cc629bf444e89f68cbb34ec48723a82924da6d2e326d022ce3cca032dec401a12f1b7ac7baa4ce56e43b6c3a4c309e7f8882e0950376eec37aadbd96
+  checksum: 10c0/0f6a6573bd898c3e1ba89b095881c3db01f60d260ce621dd93d326a244e9fc15abce64ff53b154b668dae4d092d1adfc0eecf8cad6419e9ed7aaacd05e0449e9
   languageName: node
   linkType: hard
 

--- a/tests/integration/webpack/yarn.lock
+++ b/tests/integration/webpack/yarn.lock
@@ -93,7 +93,7 @@ __metadata:
 
 "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::locator=webpack-react-typescript-example%40workspace%3A.":
   version: 0.1
-  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=c656dd&locator=webpack-react-typescript-example%40workspace%3A."
+  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=27ecc2&locator=webpack-react-typescript-example%40workspace%3A."
   dependencies:
     unplugin: "npm:^2.3.4"
   peerDependencies:
@@ -119,7 +119,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/b05233d8cc629bf444e89f68cbb34ec48723a82924da6d2e326d022ce3cca032dec401a12f1b7ac7baa4ce56e43b6c3a4c309e7f8882e0950376eec37aadbd96
+  checksum: 10c0/0f6a6573bd898c3e1ba89b095881c3db01f60d260ce621dd93d326a244e9fc15abce64ff53b154b668dae4d092d1adfc0eecf8cad6419e9ed7aaacd05e0449e9
   languageName: node
   linkType: hard
 

--- a/tests/unit/__snapshots__/index.test.ts.snap
+++ b/tests/unit/__snapshots__/index.test.ts.snap
@@ -46,6 +46,197 @@ console.log(/* (attached comment) */ A[0]);
 //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIiwiIl0sInNvdXJjZXNDb250ZW50IjpbIi8vIENyZWF0ZSBjb25mbGljdGluZyBiaW5kaW5ncyBmb3IgdGhlIGRlZmF1bHQgbmFtZXMgb2YgdGhlIGhlbHBlcnMuXG5jb25zdCAkID0gMTIzO1xuY29uc3QgRCA9IDQ1NjtcbmNvbnNvbGUubG9nKC8qIChhdHRhY2hlZCBjb21tZW50KSAqLyBcInRlc3RcIik7XG4iLCIiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6Ijs7OztBQUFBO0FBQ0EsTUFBTSxDQUFDLEdBQUc7QUFDVixNQUFNLENBQUMsR0FBRztBQUNWLE9BQU8sQ0FBQyxHQUFHLDBCQUEwQixJQUFNIiwiaWdub3JlTGlzdCI6WzFdfQ=="
 `;
 
+exports[`should be able to set a custom expression addToDictionary helper > for excluded-file 1`] = `
+"// datadog-privacy-allowlist-exclude-file
+console.log(
+  "Should",
+  'not',
+  \`be\`,
+  "allowlisted"
+);
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIiwiIl0sInNvdXJjZXNDb250ZW50IjpbIi8vIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1maWxlXG5jb25zb2xlLmxvZyhcbiAgXCJTaG91bGRcIixcbiAgJ25vdCcsXG4gIGBiZWAsXG4gIFwiYWxsb3dsaXN0ZWRcIlxuKTtcbiIsIiJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQTtBQUNBLE9BQU8sQ0FBQyxHQUFHO0FBQ1gsRUFBRSxRQUFRO0FBQ1YsRUFBRSxLQUFLO0FBQ1AsR0FBRyxFQUFFO0FBQ0wsRUFBRSxhQUFhO0FBQ2YiLCJpZ25vcmVMaXN0IjpbMV19"
+`;
+
+exports[`should be able to set a custom expression addToDictionary helper > for excluded-lines 1`] = `
+"const $ = (v) => console.log(v);
+const D = $([
+  'not excluded',
+]);
+const tag = () => { };
+
+// Should be able to exclude any kind of string with an exclude-line.
+console.log(
+  D[0],
+  "exclude line 1", // datadog-privacy-allowlist-exclude-line
+  D[0],
+  'exclude line 2', // datadog-privacy-allowlist-exclude-line
+  D[0],
+  \`exclude line 3\`, // datadog-privacy-allowlist-exclude-line
+  D[0],
+  tag\`exclude line 4\`, // datadog-privacy-allowlist-exclude-line
+  D[0],
+);
+
+// Block comments should also work.
+console.log(
+  D[0],
+  "block 1", /* datadog-privacy-allowlist-exclude-line */
+  D[0],
+  'block 2', /* datadog-privacy-allowlist-exclude-line */
+  D[0],
+  \`block 3\`, /* datadog-privacy-allowlist-exclude-line */
+  D[0],
+  tag\`block 4\`, /* datadog-privacy-allowlist-exclude-line */
+  D[0],
+);
+
+// Prefixed block comments should also work.
+console.log(
+  D[0],
+  /* datadog-privacy-allowlist-exclude-line */ "prefixed block 1",
+  D[0],
+  /* datadog-privacy-allowlist-exclude-line */ 'prefixed block 2',
+  D[0],
+  /* datadog-privacy-allowlist-exclude-line */ \`prefixed block 3\`,
+  D[0],
+  /* datadog-privacy-allowlist-exclude-line */ tag\`prefixed block 4\`,
+  D[0],
+);
+
+// Multiline block comments should also work.
+console.log(
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-line
+   */ "multiline block 1",
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-line
+   */ 'multiline block 2',
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-line
+   */ \`multiline block 3\`,
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-line
+   */ tag\`multiline block 4\`,
+  D[0],
+);
+
+// Should be able to exclude any kind of string with an exclude-next-line.
+console.log(
+  D[0],
+  // datadog-privacy-allowlist-exclude-next-line
+  "exclude next line 1",
+  D[0],
+  // datadog-privacy-allowlist-exclude-next-line
+  'exclude next line 2',
+  D[0],
+  // datadog-privacy-allowlist-exclude-next-line
+  \`exclude next line 3\`,
+  D[0],
+  // datadog-privacy-allowlist-exclude-next-line
+  tag\`exclude next line 4\`,
+  D[0],
+);
+
+// Block comments should also work for exclude-next-line.
+console.log(
+  D[0],
+  /* datadog-privacy-allowlist-exclude-next-line */
+  "exclude next line block 1",
+  D[0],
+  /* datadog-privacy-allowlist-exclude-next-line */
+  'exclude next line block 2',
+  D[0],
+  /* datadog-privacy-allowlist-exclude-next-line */
+  \`exclude next line block 3\`,
+  D[0],
+  /* datadog-privacy-allowlist-exclude-next-line */
+  tag\`exclude next line block 4\`,
+  D[0],
+);
+
+// Multiline block comments should also work for exclude-next-line.
+console.log(
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-next-line
+   */
+  "exclude next line multiline block 1",
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-next-line
+   */
+  'exclude next line multiline block 2',
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-next-line
+   */
+  \`exclude next line multiline block 3\`,
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-next-line
+   */
+  tag\`exclude next line multiline block 4\`,
+  D[0],
+);
+
+// We should be able to exclude a range of lines.
+console.log(
+  D[0],
+  // datadog-privacy-allowlist-exclude-begin
+  "exclude range 1",
+  'exclude range 2',
+  \`exclude range 3\`,
+  tag\`exclude range 4\`,
+  // datadog-privacy-allowlist-exclude-end
+  D[0],
+);
+
+// We should be able to exclude a range of with a block comment.
+console.log(
+  D[0],
+  /* datadog-privacy-allowlist-exclude-begin */
+  "exclude range with block comment 1",
+  'exclude range with block comment 2',
+  \`exclude range with block comment 3\`,
+  tag\`exclude range with block comment 4\`,
+  /* datadog-privacy-allowlist-exclude-end */
+  D[0],
+);
+
+// Extra 'exclude-begin' directives inside an exclusion and 'exclude-end'
+// directives outside of an exclusion should have no effect.
+console.log(
+  D[0],
+  // datadog-privacy-allowlist-exclude-end
+  D[0],
+  // datadog-privacy-allowlist-exclude-begin
+  "exclude range with extra directives 1",
+  'exclude range with extra directives 2',
+  // datadog-privacy-allowlist-exclude-begin
+  \`exclude range with extra directives 3\`,
+  tag\`exclude range with extra directives 4\`,
+  // datadog-privacy-allowlist-exclude-end
+  D[0],
+);
+
+// An unterminated 'exclude-begin' should cover the rest of the file. (And extra
+// 'exclude-begins' after that point should be ignored.)
+console.log(
+  D[0],
+  /* datadog-privacy-allowlist-exclude-begin */
+  "exclude range with unterminated comment 1",
+  'exclude range with unterminated comment 2',
+  /* datadog-privacy-allowlist-exclude-begin */
+  \`exclude range with unterminated comment 3\`,
+  tag\`exclude range with unterminated comment 4\`,
+);
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIiwiIl0sInNvdXJjZXNDb250ZW50IjpbImNvbnN0IHRhZyA9ICgpID0+IHsgfTtcblxuLy8gU2hvdWxkIGJlIGFibGUgdG8gZXhjbHVkZSBhbnkga2luZCBvZiBzdHJpbmcgd2l0aCBhbiBleGNsdWRlLWxpbmUuXG5jb25zb2xlLmxvZyhcbiAgJ25vdCBleGNsdWRlZCcsXG4gIFwiZXhjbHVkZSBsaW5lIDFcIiwgLy8gZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmVcbiAgJ25vdCBleGNsdWRlZCcsXG4gICdleGNsdWRlIGxpbmUgMicsIC8vIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1saW5lXG4gICdub3QgZXhjbHVkZWQnLFxuICBgZXhjbHVkZSBsaW5lIDNgLCAvLyBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtbGluZVxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgdGFnYGV4Y2x1ZGUgbGluZSA0YCwgLy8gZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmVcbiAgJ25vdCBleGNsdWRlZCcsXG4pO1xuXG4vLyBCbG9jayBjb21tZW50cyBzaG91bGQgYWxzbyB3b3JrLlxuY29uc29sZS5sb2coXG4gICdub3QgZXhjbHVkZWQnLFxuICBcImJsb2NrIDFcIiwgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmUgKi9cbiAgJ25vdCBleGNsdWRlZCcsXG4gICdibG9jayAyJywgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmUgKi9cbiAgJ25vdCBleGNsdWRlZCcsXG4gIGBibG9jayAzYCwgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmUgKi9cbiAgJ25vdCBleGNsdWRlZCcsXG4gIHRhZ2BibG9jayA0YCwgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmUgKi9cbiAgJ25vdCBleGNsdWRlZCcsXG4pO1xuXG4vLyBQcmVmaXhlZCBibG9jayBjb21tZW50cyBzaG91bGQgYWxzbyB3b3JrLlxuY29uc29sZS5sb2coXG4gICdub3QgZXhjbHVkZWQnLFxuICAvKiBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtbGluZSAqLyBcInByZWZpeGVkIGJsb2NrIDFcIixcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8qIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1saW5lICovICdwcmVmaXhlZCBibG9jayAyJyxcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8qIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1saW5lICovIGBwcmVmaXhlZCBibG9jayAzYCxcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8qIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1saW5lICovIHRhZ2BwcmVmaXhlZCBibG9jayA0YCxcbiAgJ25vdCBleGNsdWRlZCcsXG4pO1xuXG4vLyBNdWx0aWxpbmUgYmxvY2sgY29tbWVudHMgc2hvdWxkIGFsc28gd29yay5cbmNvbnNvbGUubG9nKFxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgLypcbiAgIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1saW5lXG4gICAqLyBcIm11bHRpbGluZSBibG9jayAxXCIsXG4gICdub3QgZXhjbHVkZWQnLFxuICAvKlxuICAgZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmVcbiAgICovICdtdWx0aWxpbmUgYmxvY2sgMicsXG4gICdub3QgZXhjbHVkZWQnLFxuICAvKlxuICAgZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmVcbiAgICovIGBtdWx0aWxpbmUgYmxvY2sgM2AsXG4gICdub3QgZXhjbHVkZWQnLFxuICAvKlxuICAgZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmVcbiAgICovIHRhZ2BtdWx0aWxpbmUgYmxvY2sgNGAsXG4gICdub3QgZXhjbHVkZWQnLFxuKTtcblxuLy8gU2hvdWxkIGJlIGFibGUgdG8gZXhjbHVkZSBhbnkga2luZCBvZiBzdHJpbmcgd2l0aCBhbiBleGNsdWRlLW5leHQtbGluZS5cbmNvbnNvbGUubG9nKFxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgLy8gZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLW5leHQtbGluZVxuICBcImV4Y2x1ZGUgbmV4dCBsaW5lIDFcIixcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8vIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1uZXh0LWxpbmVcbiAgJ2V4Y2x1ZGUgbmV4dCBsaW5lIDInLFxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgLy8gZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLW5leHQtbGluZVxuICBgZXhjbHVkZSBuZXh0IGxpbmUgM2AsXG4gICdub3QgZXhjbHVkZWQnLFxuICAvLyBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtbmV4dC1saW5lXG4gIHRhZ2BleGNsdWRlIG5leHQgbGluZSA0YCxcbiAgJ25vdCBleGNsdWRlZCcsXG4pO1xuXG4vLyBCbG9jayBjb21tZW50cyBzaG91bGQgYWxzbyB3b3JrIGZvciBleGNsdWRlLW5leHQtbGluZS5cbmNvbnNvbGUubG9nKFxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLW5leHQtbGluZSAqL1xuICBcImV4Y2x1ZGUgbmV4dCBsaW5lIGJsb2NrIDFcIixcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8qIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1uZXh0LWxpbmUgKi9cbiAgJ2V4Y2x1ZGUgbmV4dCBsaW5lIGJsb2NrIDInLFxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLW5leHQtbGluZSAqL1xuICBgZXhjbHVkZSBuZXh0IGxpbmUgYmxvY2sgM2AsXG4gICdub3QgZXhjbHVkZWQnLFxuICAvKiBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtbmV4dC1saW5lICovXG4gIHRhZ2BleGNsdWRlIG5leHQgbGluZSBibG9jayA0YCxcbiAgJ25vdCBleGNsdWRlZCcsXG4pO1xuXG4vLyBNdWx0aWxpbmUgYmxvY2sgY29tbWVudHMgc2hvdWxkIGFsc28gd29yayBmb3IgZXhjbHVkZS1uZXh0LWxpbmUuXG5jb25zb2xlLmxvZyhcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8qXG4gICBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtbmV4dC1saW5lXG4gICAqL1xuICBcImV4Y2x1ZGUgbmV4dCBsaW5lIG11bHRpbGluZSBibG9jayAxXCIsXG4gICdub3QgZXhjbHVkZWQnLFxuICAvKlxuICAgZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLW5leHQtbGluZVxuICAgKi9cbiAgJ2V4Y2x1ZGUgbmV4dCBsaW5lIG11bHRpbGluZSBibG9jayAyJyxcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8qXG4gICBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtbmV4dC1saW5lXG4gICAqL1xuICBgZXhjbHVkZSBuZXh0IGxpbmUgbXVsdGlsaW5lIGJsb2NrIDNgLFxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgLypcbiAgIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1uZXh0LWxpbmVcbiAgICovXG4gIHRhZ2BleGNsdWRlIG5leHQgbGluZSBtdWx0aWxpbmUgYmxvY2sgNGAsXG4gICdub3QgZXhjbHVkZWQnLFxuKTtcblxuLy8gV2Ugc2hvdWxkIGJlIGFibGUgdG8gZXhjbHVkZSBhIHJhbmdlIG9mIGxpbmVzLlxuY29uc29sZS5sb2coXG4gICdub3QgZXhjbHVkZWQnLFxuICAvLyBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtYmVnaW5cbiAgXCJleGNsdWRlIHJhbmdlIDFcIixcbiAgJ2V4Y2x1ZGUgcmFuZ2UgMicsXG4gIGBleGNsdWRlIHJhbmdlIDNgLFxuICB0YWdgZXhjbHVkZSByYW5nZSA0YCxcbiAgLy8gZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWVuZFxuICAnbm90IGV4Y2x1ZGVkJyxcbik7XG5cbi8vIFdlIHNob3VsZCBiZSBhYmxlIHRvIGV4Y2x1ZGUgYSByYW5nZSBvZiB3aXRoIGEgYmxvY2sgY29tbWVudC5cbmNvbnNvbGUubG9nKFxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWJlZ2luICovXG4gIFwiZXhjbHVkZSByYW5nZSB3aXRoIGJsb2NrIGNvbW1lbnQgMVwiLFxuICAnZXhjbHVkZSByYW5nZSB3aXRoIGJsb2NrIGNvbW1lbnQgMicsXG4gIGBleGNsdWRlIHJhbmdlIHdpdGggYmxvY2sgY29tbWVudCAzYCxcbiAgdGFnYGV4Y2x1ZGUgcmFuZ2Ugd2l0aCBibG9jayBjb21tZW50IDRgLFxuICAvKiBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtZW5kICovXG4gICdub3QgZXhjbHVkZWQnLFxuKTtcblxuLy8gRXh0cmEgJ2V4Y2x1ZGUtYmVnaW4nIGRpcmVjdGl2ZXMgaW5zaWRlIGFuIGV4Y2x1c2lvbiBhbmQgJ2V4Y2x1ZGUtZW5kJ1xuLy8gZGlyZWN0aXZlcyBvdXRzaWRlIG9mIGFuIGV4Y2x1c2lvbiBzaG91bGQgaGF2ZSBubyBlZmZlY3QuXG5jb25zb2xlLmxvZyhcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8vIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1lbmRcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8vIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1iZWdpblxuICBcImV4Y2x1ZGUgcmFuZ2Ugd2l0aCBleHRyYSBkaXJlY3RpdmVzIDFcIixcbiAgJ2V4Y2x1ZGUgcmFuZ2Ugd2l0aCBleHRyYSBkaXJlY3RpdmVzIDInLFxuICAvLyBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtYmVnaW5cbiAgYGV4Y2x1ZGUgcmFuZ2Ugd2l0aCBleHRyYSBkaXJlY3RpdmVzIDNgLFxuICB0YWdgZXhjbHVkZSByYW5nZSB3aXRoIGV4dHJhIGRpcmVjdGl2ZXMgNGAsXG4gIC8vIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1lbmRcbiAgJ25vdCBleGNsdWRlZCcsXG4pO1xuXG4vLyBBbiB1bnRlcm1pbmF0ZWQgJ2V4Y2x1ZGUtYmVnaW4nIHNob3VsZCBjb3ZlciB0aGUgcmVzdCBvZiB0aGUgZmlsZS4gKEFuZCBleHRyYVxuLy8gJ2V4Y2x1ZGUtYmVnaW5zJyBhZnRlciB0aGF0IHBvaW50IHNob3VsZCBiZSBpZ25vcmVkLilcbmNvbnNvbGUubG9nKFxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWJlZ2luICovXG4gIFwiZXhjbHVkZSByYW5nZSB3aXRoIHVudGVybWluYXRlZCBjb21tZW50IDFcIixcbiAgJ2V4Y2x1ZGUgcmFuZ2Ugd2l0aCB1bnRlcm1pbmF0ZWQgY29tbWVudCAyJyxcbiAgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWJlZ2luICovXG4gIGBleGNsdWRlIHJhbmdlIHdpdGggdW50ZXJtaW5hdGVkIGNvbW1lbnQgM2AsXG4gIHRhZ2BleGNsdWRlIHJhbmdlIHdpdGggdW50ZXJtaW5hdGVkIGNvbW1lbnQgNGAsXG4pO1xuIiwiIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7Ozs7QUFBQSxNQUFNLEdBQUcsR0FBRyxNQUFNO0FBQ2xCO0FBQ0E7QUFDQSxPQUFPLENBQUMsR0FBRztBQUNYLEVBQUUsSUFBYztBQUNoQixFQUFFLGdCQUFnQjtBQUNsQixFQUFFLElBQWM7QUFDaEIsRUFBRSxnQkFBZ0I7QUFDbEIsRUFBRSxJQUFjO0FBQ2hCLEdBQUcsY0FBYztBQUNqQixFQUFFLElBQWM7QUFDaEIsRUFBRSxHQUFHLENBQUMsY0FBYztBQUNwQixFQUFFLElBQWM7QUFDaEI7QUFDQTtBQUNBO0FBQ0EsT0FBTyxDQUFDLEdBQUc7QUFDWCxFQUFFLElBQWM7QUFDaEIsRUFBRSxTQUFTO0FBQ1gsRUFBRSxJQUFjO0FBQ2hCLEVBQUUsU0FBUztBQUNYLEVBQUUsSUFBYztBQUNoQixHQUFHLE9BQU87QUFDVixFQUFFLElBQWM7QUFDaEIsRUFBRSxHQUFHLENBQUMsT0FBTztBQUNiLEVBQUUsSUFBYztBQUNoQjtBQUNBO0FBQ0E7QUFDQSxPQUFPLENBQUMsR0FBRztBQUNYLEVBQUUsSUFBYztBQUNoQiwrQ0FBK0Msa0JBQWtCO0FBQ2pFLEVBQUUsSUFBYztBQUNoQiwrQ0FBK0Msa0JBQWtCO0FBQ2pFLEVBQUUsSUFBYztBQUNoQixnREFBZ0QsZ0JBQWdCO0FBQ2hFLEVBQUUsSUFBYztBQUNoQiwrQ0FBK0MsR0FBRyxDQUFDLGdCQUFnQjtBQUNuRSxFQUFFLElBQWM7QUFDaEI7QUFDQTtBQUNBO0FBQ0EsT0FBTyxDQUFDLEdBQUc7QUFDWCxFQUFFLElBQWM7QUFDaEI7QUFDQTtBQUNBLE1BQU0sbUJBQW1CO0FBQ3pCLEVBQUUsSUFBYztBQUNoQjtBQUNBO0FBQ0EsTUFBTSxtQkFBbUI7QUFDekIsRUFBRSxJQUFjO0FBQ2hCO0FBQ0E7QUFDQSxPQUFPLGlCQUFpQjtBQUN4QixFQUFFLElBQWM7QUFDaEI7QUFDQTtBQUNBLE1BQU0sR0FBRyxDQUFDLGlCQUFpQjtBQUMzQixFQUFFLElBQWM7QUFDaEI7QUFDQTtBQUNBO0FBQ0EsT0FBTyxDQUFDLEdBQUc7QUFDWCxFQUFFLElBQWM7QUFDaEI7QUFDQSxFQUFFLHFCQUFxQjtBQUN2QixFQUFFLElBQWM7QUFDaEI7QUFDQSxFQUFFLHFCQUFxQjtBQUN2QixFQUFFLElBQWM7QUFDaEI7QUFDQSxHQUFHLG1CQUFtQjtBQUN0QixFQUFFLElBQWM7QUFDaEI7QUFDQSxFQUFFLEdBQUcsQ0FBQyxtQkFBbUI7QUFDekIsRUFBRSxJQUFjO0FBQ2hCO0FBQ0E7QUFDQTtBQUNBLE9BQU8sQ0FBQyxHQUFHO0FBQ1gsRUFBRSxJQUFjO0FBQ2hCO0FBQ0EsRUFBRSwyQkFBMkI7QUFDN0IsRUFBRSxJQUFjO0FBQ2hCO0FBQ0EsRUFBRSwyQkFBMkI7QUFDN0IsRUFBRSxJQUFjO0FBQ2hCO0FBQ0EsR0FBRyx5QkFBeUI7QUFDNUIsRUFBRSxJQUFjO0FBQ2hCO0FBQ0EsRUFBRSxHQUFHLENBQUMseUJBQXlCO0FBQy9CLEVBQUUsSUFBYztBQUNoQjtBQUNBO0FBQ0E7QUFDQSxPQUFPLENBQUMsR0FBRztBQUNYLEVBQUUsSUFBYztBQUNoQjtBQUNBO0FBQ0E7QUFDQSxFQUFFLHFDQUFxQztBQUN2QyxFQUFFLElBQWM7QUFDaEI7QUFDQTtBQUNBO0FBQ0EsRUFBRSxxQ0FBcUM7QUFDdkMsRUFBRSxJQUFjO0FBQ2hCO0FBQ0E7QUFDQTtBQUNBLEdBQUcsbUNBQW1DO0FBQ3RDLEVBQUUsSUFBYztBQUNoQjtBQUNBO0FBQ0E7QUFDQSxFQUFFLEdBQUcsQ0FBQyxtQ0FBbUM7QUFDekMsRUFBRSxJQUFjO0FBQ2hCO0FBQ0E7QUFDQTtBQUNBLE9BQU8sQ0FBQyxHQUFHO0FBQ1gsRUFBRSxJQUFjO0FBQ2hCO0FBQ0EsRUFBRSxpQkFBaUI7QUFDbkIsRUFBRSxpQkFBaUI7QUFDbkIsR0FBRyxlQUFlO0FBQ2xCLEVBQUUsR0FBRyxDQUFDLGVBQWU7QUFDckI7QUFDQSxFQUFFLElBQWM7QUFDaEI7QUFDQTtBQUNBO0FBQ0EsT0FBTyxDQUFDLEdBQUc7QUFDWCxFQUFFLElBQWM7QUFDaEI7QUFDQSxFQUFFLG9DQUFvQztBQUN0QyxFQUFFLG9DQUFvQztBQUN0QyxHQUFHLGtDQUFrQztBQUNyQyxFQUFFLEdBQUcsQ0FBQyxrQ0FBa0M7QUFDeEM7QUFDQSxFQUFFLElBQWM7QUFDaEI7QUFDQTtBQUNBO0FBQ0E7QUFDQSxPQUFPLENBQUMsR0FBRztBQUNYLEVBQUUsSUFBYztBQUNoQjtBQUNBLEVBQUUsSUFBYztBQUNoQjtBQUNBLEVBQUUsdUNBQXVDO0FBQ3pDLEVBQUUsdUNBQXVDO0FBQ3pDO0FBQ0EsR0FBRyxxQ0FBcUM7QUFDeEMsRUFBRSxHQUFHLENBQUMscUNBQXFDO0FBQzNDO0FBQ0EsRUFBRSxJQUFjO0FBQ2hCO0FBQ0E7QUFDQTtBQUNBO0FBQ0EsT0FBTyxDQUFDLEdBQUc7QUFDWCxFQUFFLElBQWM7QUFDaEI7QUFDQSxFQUFFLDJDQUEyQztBQUM3QyxFQUFFLDJDQUEyQztBQUM3QztBQUNBLEdBQUcseUNBQXlDO0FBQzVDLEVBQUUsR0FBRyxDQUFDLHlDQUF5QztBQUMvQyIsImlnbm9yZUxpc3QiOlsxXX0="
+`;
+
 exports[`should be able to set a custom expression addToDictionary helper > for excluded-strings 1`] = `
 "// URLS (excluded by URL_STRINGS_REGEX):
 console.log(
@@ -667,6 +858,197 @@ const $ = 123;
 const D = 456;
 console.log(/* (attached comment) */ A[0]);
 //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIiwiIl0sInNvdXJjZXNDb250ZW50IjpbIi8vIENyZWF0ZSBjb25mbGljdGluZyBiaW5kaW5ncyBmb3IgdGhlIGRlZmF1bHQgbmFtZXMgb2YgdGhlIGhlbHBlcnMuXG5jb25zdCAkID0gMTIzO1xuY29uc3QgRCA9IDQ1NjtcbmNvbnNvbGUubG9nKC8qIChhdHRhY2hlZCBjb21tZW50KSAqLyBcInRlc3RcIik7XG4iLCIiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6Ijs7OztBQUFBO0FBQ0EsTUFBTSxDQUFDLEdBQUc7QUFDVixNQUFNLENBQUMsR0FBRztBQUNWLE9BQU8sQ0FBQyxHQUFHLDBCQUEwQixJQUFNIiwiaWdub3JlTGlzdCI6WzFdfQ=="
+`;
+
+exports[`should be able to set a custom imported addToDictionary helper > for excluded-file 1`] = `
+"// datadog-privacy-allowlist-exclude-file
+console.log(
+  "Should",
+  'not',
+  \`be\`,
+  "allowlisted"
+);
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIiwiIl0sInNvdXJjZXNDb250ZW50IjpbIi8vIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1maWxlXG5jb25zb2xlLmxvZyhcbiAgXCJTaG91bGRcIixcbiAgJ25vdCcsXG4gIGBiZWAsXG4gIFwiYWxsb3dsaXN0ZWRcIlxuKTtcbiIsIiJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQTtBQUNBLE9BQU8sQ0FBQyxHQUFHO0FBQ1gsRUFBRSxRQUFRO0FBQ1YsRUFBRSxLQUFLO0FBQ1AsR0FBRyxFQUFFO0FBQ0wsRUFBRSxhQUFhO0FBQ2YiLCJpZ25vcmVMaXN0IjpbMV19"
+`;
+
+exports[`should be able to set a custom imported addToDictionary helper > for excluded-lines 1`] = `
+"import { addToDictionary as $ } from '@custom/helpers.mjs';
+const D = $([
+  'not excluded',
+]);
+const tag = () => { };
+
+// Should be able to exclude any kind of string with an exclude-line.
+console.log(
+  D[0],
+  "exclude line 1", // datadog-privacy-allowlist-exclude-line
+  D[0],
+  'exclude line 2', // datadog-privacy-allowlist-exclude-line
+  D[0],
+  \`exclude line 3\`, // datadog-privacy-allowlist-exclude-line
+  D[0],
+  tag\`exclude line 4\`, // datadog-privacy-allowlist-exclude-line
+  D[0],
+);
+
+// Block comments should also work.
+console.log(
+  D[0],
+  "block 1", /* datadog-privacy-allowlist-exclude-line */
+  D[0],
+  'block 2', /* datadog-privacy-allowlist-exclude-line */
+  D[0],
+  \`block 3\`, /* datadog-privacy-allowlist-exclude-line */
+  D[0],
+  tag\`block 4\`, /* datadog-privacy-allowlist-exclude-line */
+  D[0],
+);
+
+// Prefixed block comments should also work.
+console.log(
+  D[0],
+  /* datadog-privacy-allowlist-exclude-line */ "prefixed block 1",
+  D[0],
+  /* datadog-privacy-allowlist-exclude-line */ 'prefixed block 2',
+  D[0],
+  /* datadog-privacy-allowlist-exclude-line */ \`prefixed block 3\`,
+  D[0],
+  /* datadog-privacy-allowlist-exclude-line */ tag\`prefixed block 4\`,
+  D[0],
+);
+
+// Multiline block comments should also work.
+console.log(
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-line
+   */ "multiline block 1",
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-line
+   */ 'multiline block 2',
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-line
+   */ \`multiline block 3\`,
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-line
+   */ tag\`multiline block 4\`,
+  D[0],
+);
+
+// Should be able to exclude any kind of string with an exclude-next-line.
+console.log(
+  D[0],
+  // datadog-privacy-allowlist-exclude-next-line
+  "exclude next line 1",
+  D[0],
+  // datadog-privacy-allowlist-exclude-next-line
+  'exclude next line 2',
+  D[0],
+  // datadog-privacy-allowlist-exclude-next-line
+  \`exclude next line 3\`,
+  D[0],
+  // datadog-privacy-allowlist-exclude-next-line
+  tag\`exclude next line 4\`,
+  D[0],
+);
+
+// Block comments should also work for exclude-next-line.
+console.log(
+  D[0],
+  /* datadog-privacy-allowlist-exclude-next-line */
+  "exclude next line block 1",
+  D[0],
+  /* datadog-privacy-allowlist-exclude-next-line */
+  'exclude next line block 2',
+  D[0],
+  /* datadog-privacy-allowlist-exclude-next-line */
+  \`exclude next line block 3\`,
+  D[0],
+  /* datadog-privacy-allowlist-exclude-next-line */
+  tag\`exclude next line block 4\`,
+  D[0],
+);
+
+// Multiline block comments should also work for exclude-next-line.
+console.log(
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-next-line
+   */
+  "exclude next line multiline block 1",
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-next-line
+   */
+  'exclude next line multiline block 2',
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-next-line
+   */
+  \`exclude next line multiline block 3\`,
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-next-line
+   */
+  tag\`exclude next line multiline block 4\`,
+  D[0],
+);
+
+// We should be able to exclude a range of lines.
+console.log(
+  D[0],
+  // datadog-privacy-allowlist-exclude-begin
+  "exclude range 1",
+  'exclude range 2',
+  \`exclude range 3\`,
+  tag\`exclude range 4\`,
+  // datadog-privacy-allowlist-exclude-end
+  D[0],
+);
+
+// We should be able to exclude a range of with a block comment.
+console.log(
+  D[0],
+  /* datadog-privacy-allowlist-exclude-begin */
+  "exclude range with block comment 1",
+  'exclude range with block comment 2',
+  \`exclude range with block comment 3\`,
+  tag\`exclude range with block comment 4\`,
+  /* datadog-privacy-allowlist-exclude-end */
+  D[0],
+);
+
+// Extra 'exclude-begin' directives inside an exclusion and 'exclude-end'
+// directives outside of an exclusion should have no effect.
+console.log(
+  D[0],
+  // datadog-privacy-allowlist-exclude-end
+  D[0],
+  // datadog-privacy-allowlist-exclude-begin
+  "exclude range with extra directives 1",
+  'exclude range with extra directives 2',
+  // datadog-privacy-allowlist-exclude-begin
+  \`exclude range with extra directives 3\`,
+  tag\`exclude range with extra directives 4\`,
+  // datadog-privacy-allowlist-exclude-end
+  D[0],
+);
+
+// An unterminated 'exclude-begin' should cover the rest of the file. (And extra
+// 'exclude-begins' after that point should be ignored.)
+console.log(
+  D[0],
+  /* datadog-privacy-allowlist-exclude-begin */
+  "exclude range with unterminated comment 1",
+  'exclude range with unterminated comment 2',
+  /* datadog-privacy-allowlist-exclude-begin */
+  \`exclude range with unterminated comment 3\`,
+  tag\`exclude range with unterminated comment 4\`,
+);
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIiwiIl0sInNvdXJjZXNDb250ZW50IjpbImNvbnN0IHRhZyA9ICgpID0+IHsgfTtcblxuLy8gU2hvdWxkIGJlIGFibGUgdG8gZXhjbHVkZSBhbnkga2luZCBvZiBzdHJpbmcgd2l0aCBhbiBleGNsdWRlLWxpbmUuXG5jb25zb2xlLmxvZyhcbiAgJ25vdCBleGNsdWRlZCcsXG4gIFwiZXhjbHVkZSBsaW5lIDFcIiwgLy8gZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmVcbiAgJ25vdCBleGNsdWRlZCcsXG4gICdleGNsdWRlIGxpbmUgMicsIC8vIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1saW5lXG4gICdub3QgZXhjbHVkZWQnLFxuICBgZXhjbHVkZSBsaW5lIDNgLCAvLyBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtbGluZVxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgdGFnYGV4Y2x1ZGUgbGluZSA0YCwgLy8gZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmVcbiAgJ25vdCBleGNsdWRlZCcsXG4pO1xuXG4vLyBCbG9jayBjb21tZW50cyBzaG91bGQgYWxzbyB3b3JrLlxuY29uc29sZS5sb2coXG4gICdub3QgZXhjbHVkZWQnLFxuICBcImJsb2NrIDFcIiwgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmUgKi9cbiAgJ25vdCBleGNsdWRlZCcsXG4gICdibG9jayAyJywgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmUgKi9cbiAgJ25vdCBleGNsdWRlZCcsXG4gIGBibG9jayAzYCwgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmUgKi9cbiAgJ25vdCBleGNsdWRlZCcsXG4gIHRhZ2BibG9jayA0YCwgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmUgKi9cbiAgJ25vdCBleGNsdWRlZCcsXG4pO1xuXG4vLyBQcmVmaXhlZCBibG9jayBjb21tZW50cyBzaG91bGQgYWxzbyB3b3JrLlxuY29uc29sZS5sb2coXG4gICdub3QgZXhjbHVkZWQnLFxuICAvKiBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtbGluZSAqLyBcInByZWZpeGVkIGJsb2NrIDFcIixcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8qIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1saW5lICovICdwcmVmaXhlZCBibG9jayAyJyxcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8qIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1saW5lICovIGBwcmVmaXhlZCBibG9jayAzYCxcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8qIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1saW5lICovIHRhZ2BwcmVmaXhlZCBibG9jayA0YCxcbiAgJ25vdCBleGNsdWRlZCcsXG4pO1xuXG4vLyBNdWx0aWxpbmUgYmxvY2sgY29tbWVudHMgc2hvdWxkIGFsc28gd29yay5cbmNvbnNvbGUubG9nKFxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgLypcbiAgIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1saW5lXG4gICAqLyBcIm11bHRpbGluZSBibG9jayAxXCIsXG4gICdub3QgZXhjbHVkZWQnLFxuICAvKlxuICAgZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmVcbiAgICovICdtdWx0aWxpbmUgYmxvY2sgMicsXG4gICdub3QgZXhjbHVkZWQnLFxuICAvKlxuICAgZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmVcbiAgICovIGBtdWx0aWxpbmUgYmxvY2sgM2AsXG4gICdub3QgZXhjbHVkZWQnLFxuICAvKlxuICAgZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmVcbiAgICovIHRhZ2BtdWx0aWxpbmUgYmxvY2sgNGAsXG4gICdub3QgZXhjbHVkZWQnLFxuKTtcblxuLy8gU2hvdWxkIGJlIGFibGUgdG8gZXhjbHVkZSBhbnkga2luZCBvZiBzdHJpbmcgd2l0aCBhbiBleGNsdWRlLW5leHQtbGluZS5cbmNvbnNvbGUubG9nKFxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgLy8gZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLW5leHQtbGluZVxuICBcImV4Y2x1ZGUgbmV4dCBsaW5lIDFcIixcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8vIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1uZXh0LWxpbmVcbiAgJ2V4Y2x1ZGUgbmV4dCBsaW5lIDInLFxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgLy8gZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLW5leHQtbGluZVxuICBgZXhjbHVkZSBuZXh0IGxpbmUgM2AsXG4gICdub3QgZXhjbHVkZWQnLFxuICAvLyBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtbmV4dC1saW5lXG4gIHRhZ2BleGNsdWRlIG5leHQgbGluZSA0YCxcbiAgJ25vdCBleGNsdWRlZCcsXG4pO1xuXG4vLyBCbG9jayBjb21tZW50cyBzaG91bGQgYWxzbyB3b3JrIGZvciBleGNsdWRlLW5leHQtbGluZS5cbmNvbnNvbGUubG9nKFxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLW5leHQtbGluZSAqL1xuICBcImV4Y2x1ZGUgbmV4dCBsaW5lIGJsb2NrIDFcIixcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8qIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1uZXh0LWxpbmUgKi9cbiAgJ2V4Y2x1ZGUgbmV4dCBsaW5lIGJsb2NrIDInLFxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLW5leHQtbGluZSAqL1xuICBgZXhjbHVkZSBuZXh0IGxpbmUgYmxvY2sgM2AsXG4gICdub3QgZXhjbHVkZWQnLFxuICAvKiBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtbmV4dC1saW5lICovXG4gIHRhZ2BleGNsdWRlIG5leHQgbGluZSBibG9jayA0YCxcbiAgJ25vdCBleGNsdWRlZCcsXG4pO1xuXG4vLyBNdWx0aWxpbmUgYmxvY2sgY29tbWVudHMgc2hvdWxkIGFsc28gd29yayBmb3IgZXhjbHVkZS1uZXh0LWxpbmUuXG5jb25zb2xlLmxvZyhcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8qXG4gICBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtbmV4dC1saW5lXG4gICAqL1xuICBcImV4Y2x1ZGUgbmV4dCBsaW5lIG11bHRpbGluZSBibG9jayAxXCIsXG4gICdub3QgZXhjbHVkZWQnLFxuICAvKlxuICAgZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLW5leHQtbGluZVxuICAgKi9cbiAgJ2V4Y2x1ZGUgbmV4dCBsaW5lIG11bHRpbGluZSBibG9jayAyJyxcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8qXG4gICBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtbmV4dC1saW5lXG4gICAqL1xuICBgZXhjbHVkZSBuZXh0IGxpbmUgbXVsdGlsaW5lIGJsb2NrIDNgLFxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgLypcbiAgIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1uZXh0LWxpbmVcbiAgICovXG4gIHRhZ2BleGNsdWRlIG5leHQgbGluZSBtdWx0aWxpbmUgYmxvY2sgNGAsXG4gICdub3QgZXhjbHVkZWQnLFxuKTtcblxuLy8gV2Ugc2hvdWxkIGJlIGFibGUgdG8gZXhjbHVkZSBhIHJhbmdlIG9mIGxpbmVzLlxuY29uc29sZS5sb2coXG4gICdub3QgZXhjbHVkZWQnLFxuICAvLyBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtYmVnaW5cbiAgXCJleGNsdWRlIHJhbmdlIDFcIixcbiAgJ2V4Y2x1ZGUgcmFuZ2UgMicsXG4gIGBleGNsdWRlIHJhbmdlIDNgLFxuICB0YWdgZXhjbHVkZSByYW5nZSA0YCxcbiAgLy8gZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWVuZFxuICAnbm90IGV4Y2x1ZGVkJyxcbik7XG5cbi8vIFdlIHNob3VsZCBiZSBhYmxlIHRvIGV4Y2x1ZGUgYSByYW5nZSBvZiB3aXRoIGEgYmxvY2sgY29tbWVudC5cbmNvbnNvbGUubG9nKFxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWJlZ2luICovXG4gIFwiZXhjbHVkZSByYW5nZSB3aXRoIGJsb2NrIGNvbW1lbnQgMVwiLFxuICAnZXhjbHVkZSByYW5nZSB3aXRoIGJsb2NrIGNvbW1lbnQgMicsXG4gIGBleGNsdWRlIHJhbmdlIHdpdGggYmxvY2sgY29tbWVudCAzYCxcbiAgdGFnYGV4Y2x1ZGUgcmFuZ2Ugd2l0aCBibG9jayBjb21tZW50IDRgLFxuICAvKiBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtZW5kICovXG4gICdub3QgZXhjbHVkZWQnLFxuKTtcblxuLy8gRXh0cmEgJ2V4Y2x1ZGUtYmVnaW4nIGRpcmVjdGl2ZXMgaW5zaWRlIGFuIGV4Y2x1c2lvbiBhbmQgJ2V4Y2x1ZGUtZW5kJ1xuLy8gZGlyZWN0aXZlcyBvdXRzaWRlIG9mIGFuIGV4Y2x1c2lvbiBzaG91bGQgaGF2ZSBubyBlZmZlY3QuXG5jb25zb2xlLmxvZyhcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8vIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1lbmRcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8vIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1iZWdpblxuICBcImV4Y2x1ZGUgcmFuZ2Ugd2l0aCBleHRyYSBkaXJlY3RpdmVzIDFcIixcbiAgJ2V4Y2x1ZGUgcmFuZ2Ugd2l0aCBleHRyYSBkaXJlY3RpdmVzIDInLFxuICAvLyBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtYmVnaW5cbiAgYGV4Y2x1ZGUgcmFuZ2Ugd2l0aCBleHRyYSBkaXJlY3RpdmVzIDNgLFxuICB0YWdgZXhjbHVkZSByYW5nZSB3aXRoIGV4dHJhIGRpcmVjdGl2ZXMgNGAsXG4gIC8vIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1lbmRcbiAgJ25vdCBleGNsdWRlZCcsXG4pO1xuXG4vLyBBbiB1bnRlcm1pbmF0ZWQgJ2V4Y2x1ZGUtYmVnaW4nIHNob3VsZCBjb3ZlciB0aGUgcmVzdCBvZiB0aGUgZmlsZS4gKEFuZCBleHRyYVxuLy8gJ2V4Y2x1ZGUtYmVnaW5zJyBhZnRlciB0aGF0IHBvaW50IHNob3VsZCBiZSBpZ25vcmVkLilcbmNvbnNvbGUubG9nKFxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWJlZ2luICovXG4gIFwiZXhjbHVkZSByYW5nZSB3aXRoIHVudGVybWluYXRlZCBjb21tZW50IDFcIixcbiAgJ2V4Y2x1ZGUgcmFuZ2Ugd2l0aCB1bnRlcm1pbmF0ZWQgY29tbWVudCAyJyxcbiAgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWJlZ2luICovXG4gIGBleGNsdWRlIHJhbmdlIHdpdGggdW50ZXJtaW5hdGVkIGNvbW1lbnQgM2AsXG4gIHRhZ2BleGNsdWRlIHJhbmdlIHdpdGggdW50ZXJtaW5hdGVkIGNvbW1lbnQgNGAsXG4pO1xuIiwiIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7Ozs7QUFBQSxNQUFNLEdBQUcsR0FBRyxNQUFNO0FBQ2xCO0FBQ0E7QUFDQSxPQUFPLENBQUMsR0FBRztBQUNYLEVBQUUsSUFBYztBQUNoQixFQUFFLGdCQUFnQjtBQUNsQixFQUFFLElBQWM7QUFDaEIsRUFBRSxnQkFBZ0I7QUFDbEIsRUFBRSxJQUFjO0FBQ2hCLEdBQUcsY0FBYztBQUNqQixFQUFFLElBQWM7QUFDaEIsRUFBRSxHQUFHLENBQUMsY0FBYztBQUNwQixFQUFFLElBQWM7QUFDaEI7QUFDQTtBQUNBO0FBQ0EsT0FBTyxDQUFDLEdBQUc7QUFDWCxFQUFFLElBQWM7QUFDaEIsRUFBRSxTQUFTO0FBQ1gsRUFBRSxJQUFjO0FBQ2hCLEVBQUUsU0FBUztBQUNYLEVBQUUsSUFBYztBQUNoQixHQUFHLE9BQU87QUFDVixFQUFFLElBQWM7QUFDaEIsRUFBRSxHQUFHLENBQUMsT0FBTztBQUNiLEVBQUUsSUFBYztBQUNoQjtBQUNBO0FBQ0E7QUFDQSxPQUFPLENBQUMsR0FBRztBQUNYLEVBQUUsSUFBYztBQUNoQiwrQ0FBK0Msa0JBQWtCO0FBQ2pFLEVBQUUsSUFBYztBQUNoQiwrQ0FBK0Msa0JBQWtCO0FBQ2pFLEVBQUUsSUFBYztBQUNoQixnREFBZ0QsZ0JBQWdCO0FBQ2hFLEVBQUUsSUFBYztBQUNoQiwrQ0FBK0MsR0FBRyxDQUFDLGdCQUFnQjtBQUNuRSxFQUFFLElBQWM7QUFDaEI7QUFDQTtBQUNBO0FBQ0EsT0FBTyxDQUFDLEdBQUc7QUFDWCxFQUFFLElBQWM7QUFDaEI7QUFDQTtBQUNBLE1BQU0sbUJBQW1CO0FBQ3pCLEVBQUUsSUFBYztBQUNoQjtBQUNBO0FBQ0EsTUFBTSxtQkFBbUI7QUFDekIsRUFBRSxJQUFjO0FBQ2hCO0FBQ0E7QUFDQSxPQUFPLGlCQUFpQjtBQUN4QixFQUFFLElBQWM7QUFDaEI7QUFDQTtBQUNBLE1BQU0sR0FBRyxDQUFDLGlCQUFpQjtBQUMzQixFQUFFLElBQWM7QUFDaEI7QUFDQTtBQUNBO0FBQ0EsT0FBTyxDQUFDLEdBQUc7QUFDWCxFQUFFLElBQWM7QUFDaEI7QUFDQSxFQUFFLHFCQUFxQjtBQUN2QixFQUFFLElBQWM7QUFDaEI7QUFDQSxFQUFFLHFCQUFxQjtBQUN2QixFQUFFLElBQWM7QUFDaEI7QUFDQSxHQUFHLG1CQUFtQjtBQUN0QixFQUFFLElBQWM7QUFDaEI7QUFDQSxFQUFFLEdBQUcsQ0FBQyxtQkFBbUI7QUFDekIsRUFBRSxJQUFjO0FBQ2hCO0FBQ0E7QUFDQTtBQUNBLE9BQU8sQ0FBQyxHQUFHO0FBQ1gsRUFBRSxJQUFjO0FBQ2hCO0FBQ0EsRUFBRSwyQkFBMkI7QUFDN0IsRUFBRSxJQUFjO0FBQ2hCO0FBQ0EsRUFBRSwyQkFBMkI7QUFDN0IsRUFBRSxJQUFjO0FBQ2hCO0FBQ0EsR0FBRyx5QkFBeUI7QUFDNUIsRUFBRSxJQUFjO0FBQ2hCO0FBQ0EsRUFBRSxHQUFHLENBQUMseUJBQXlCO0FBQy9CLEVBQUUsSUFBYztBQUNoQjtBQUNBO0FBQ0E7QUFDQSxPQUFPLENBQUMsR0FBRztBQUNYLEVBQUUsSUFBYztBQUNoQjtBQUNBO0FBQ0E7QUFDQSxFQUFFLHFDQUFxQztBQUN2QyxFQUFFLElBQWM7QUFDaEI7QUFDQTtBQUNBO0FBQ0EsRUFBRSxxQ0FBcUM7QUFDdkMsRUFBRSxJQUFjO0FBQ2hCO0FBQ0E7QUFDQTtBQUNBLEdBQUcsbUNBQW1DO0FBQ3RDLEVBQUUsSUFBYztBQUNoQjtBQUNBO0FBQ0E7QUFDQSxFQUFFLEdBQUcsQ0FBQyxtQ0FBbUM7QUFDekMsRUFBRSxJQUFjO0FBQ2hCO0FBQ0E7QUFDQTtBQUNBLE9BQU8sQ0FBQyxHQUFHO0FBQ1gsRUFBRSxJQUFjO0FBQ2hCO0FBQ0EsRUFBRSxpQkFBaUI7QUFDbkIsRUFBRSxpQkFBaUI7QUFDbkIsR0FBRyxlQUFlO0FBQ2xCLEVBQUUsR0FBRyxDQUFDLGVBQWU7QUFDckI7QUFDQSxFQUFFLElBQWM7QUFDaEI7QUFDQTtBQUNBO0FBQ0EsT0FBTyxDQUFDLEdBQUc7QUFDWCxFQUFFLElBQWM7QUFDaEI7QUFDQSxFQUFFLG9DQUFvQztBQUN0QyxFQUFFLG9DQUFvQztBQUN0QyxHQUFHLGtDQUFrQztBQUNyQyxFQUFFLEdBQUcsQ0FBQyxrQ0FBa0M7QUFDeEM7QUFDQSxFQUFFLElBQWM7QUFDaEI7QUFDQTtBQUNBO0FBQ0E7QUFDQSxPQUFPLENBQUMsR0FBRztBQUNYLEVBQUUsSUFBYztBQUNoQjtBQUNBLEVBQUUsSUFBYztBQUNoQjtBQUNBLEVBQUUsdUNBQXVDO0FBQ3pDLEVBQUUsdUNBQXVDO0FBQ3pDO0FBQ0EsR0FBRyxxQ0FBcUM7QUFDeEMsRUFBRSxHQUFHLENBQUMscUNBQXFDO0FBQzNDO0FBQ0EsRUFBRSxJQUFjO0FBQ2hCO0FBQ0E7QUFDQTtBQUNBO0FBQ0EsT0FBTyxDQUFDLEdBQUc7QUFDWCxFQUFFLElBQWM7QUFDaEI7QUFDQSxFQUFFLDJDQUEyQztBQUM3QyxFQUFFLDJDQUEyQztBQUM3QztBQUNBLEdBQUcseUNBQXlDO0FBQzVDLEVBQUUsR0FBRyxDQUFDLHlDQUF5QztBQUMvQyIsImlnbm9yZUxpc3QiOlsxXX0="
 `;
 
 exports[`should be able to set a custom imported addToDictionary helper > for excluded-strings 1`] = `
@@ -1292,6 +1674,197 @@ console.log(/* (attached comment) */ A[0]);
 //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIiwiIl0sInNvdXJjZXNDb250ZW50IjpbIi8vIENyZWF0ZSBjb25mbGljdGluZyBiaW5kaW5ncyBmb3IgdGhlIGRlZmF1bHQgbmFtZXMgb2YgdGhlIGhlbHBlcnMuXG5jb25zdCAkID0gMTIzO1xuY29uc3QgRCA9IDQ1NjtcbmNvbnNvbGUubG9nKC8qIChhdHRhY2hlZCBjb21tZW50KSAqLyBcInRlc3RcIik7XG4iLCIiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6Ijs7OztBQUFBO0FBQ0EsTUFBTSxDQUFDLEdBQUc7QUFDVixNQUFNLENBQUMsR0FBRztBQUNWLE9BQU8sQ0FBQyxHQUFHLDBCQUEwQixJQUFNIiwiaWdub3JlTGlzdCI6WzFdfQ=="
 `;
 
+exports[`the CJS version should transform code correctly > for excluded-file 1`] = `
+"// datadog-privacy-allowlist-exclude-file
+console.log(
+  "Should",
+  'not',
+  \`be\`,
+  "allowlisted"
+);
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIiwiIl0sInNvdXJjZXNDb250ZW50IjpbIi8vIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1maWxlXG5jb25zb2xlLmxvZyhcbiAgXCJTaG91bGRcIixcbiAgJ25vdCcsXG4gIGBiZWAsXG4gIFwiYWxsb3dsaXN0ZWRcIlxuKTtcbiIsIiJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQTtBQUNBLE9BQU8sQ0FBQyxHQUFHO0FBQ1gsRUFBRSxRQUFRO0FBQ1YsRUFBRSxLQUFLO0FBQ1AsR0FBRyxFQUFFO0FBQ0wsRUFBRSxhQUFhO0FBQ2YiLCJpZ25vcmVMaXN0IjpbMV19"
+`;
+
+exports[`the CJS version should transform code correctly > for excluded-lines 1`] = `
+"import { $ } from ' datadog:privacy-helpers.mjs';
+const D = $([
+  'not excluded',
+]);
+const tag = () => { };
+
+// Should be able to exclude any kind of string with an exclude-line.
+console.log(
+  D[0],
+  "exclude line 1", // datadog-privacy-allowlist-exclude-line
+  D[0],
+  'exclude line 2', // datadog-privacy-allowlist-exclude-line
+  D[0],
+  \`exclude line 3\`, // datadog-privacy-allowlist-exclude-line
+  D[0],
+  tag\`exclude line 4\`, // datadog-privacy-allowlist-exclude-line
+  D[0],
+);
+
+// Block comments should also work.
+console.log(
+  D[0],
+  "block 1", /* datadog-privacy-allowlist-exclude-line */
+  D[0],
+  'block 2', /* datadog-privacy-allowlist-exclude-line */
+  D[0],
+  \`block 3\`, /* datadog-privacy-allowlist-exclude-line */
+  D[0],
+  tag\`block 4\`, /* datadog-privacy-allowlist-exclude-line */
+  D[0],
+);
+
+// Prefixed block comments should also work.
+console.log(
+  D[0],
+  /* datadog-privacy-allowlist-exclude-line */ "prefixed block 1",
+  D[0],
+  /* datadog-privacy-allowlist-exclude-line */ 'prefixed block 2',
+  D[0],
+  /* datadog-privacy-allowlist-exclude-line */ \`prefixed block 3\`,
+  D[0],
+  /* datadog-privacy-allowlist-exclude-line */ tag\`prefixed block 4\`,
+  D[0],
+);
+
+// Multiline block comments should also work.
+console.log(
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-line
+   */ "multiline block 1",
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-line
+   */ 'multiline block 2',
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-line
+   */ \`multiline block 3\`,
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-line
+   */ tag\`multiline block 4\`,
+  D[0],
+);
+
+// Should be able to exclude any kind of string with an exclude-next-line.
+console.log(
+  D[0],
+  // datadog-privacy-allowlist-exclude-next-line
+  "exclude next line 1",
+  D[0],
+  // datadog-privacy-allowlist-exclude-next-line
+  'exclude next line 2',
+  D[0],
+  // datadog-privacy-allowlist-exclude-next-line
+  \`exclude next line 3\`,
+  D[0],
+  // datadog-privacy-allowlist-exclude-next-line
+  tag\`exclude next line 4\`,
+  D[0],
+);
+
+// Block comments should also work for exclude-next-line.
+console.log(
+  D[0],
+  /* datadog-privacy-allowlist-exclude-next-line */
+  "exclude next line block 1",
+  D[0],
+  /* datadog-privacy-allowlist-exclude-next-line */
+  'exclude next line block 2',
+  D[0],
+  /* datadog-privacy-allowlist-exclude-next-line */
+  \`exclude next line block 3\`,
+  D[0],
+  /* datadog-privacy-allowlist-exclude-next-line */
+  tag\`exclude next line block 4\`,
+  D[0],
+);
+
+// Multiline block comments should also work for exclude-next-line.
+console.log(
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-next-line
+   */
+  "exclude next line multiline block 1",
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-next-line
+   */
+  'exclude next line multiline block 2',
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-next-line
+   */
+  \`exclude next line multiline block 3\`,
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-next-line
+   */
+  tag\`exclude next line multiline block 4\`,
+  D[0],
+);
+
+// We should be able to exclude a range of lines.
+console.log(
+  D[0],
+  // datadog-privacy-allowlist-exclude-begin
+  "exclude range 1",
+  'exclude range 2',
+  \`exclude range 3\`,
+  tag\`exclude range 4\`,
+  // datadog-privacy-allowlist-exclude-end
+  D[0],
+);
+
+// We should be able to exclude a range of with a block comment.
+console.log(
+  D[0],
+  /* datadog-privacy-allowlist-exclude-begin */
+  "exclude range with block comment 1",
+  'exclude range with block comment 2',
+  \`exclude range with block comment 3\`,
+  tag\`exclude range with block comment 4\`,
+  /* datadog-privacy-allowlist-exclude-end */
+  D[0],
+);
+
+// Extra 'exclude-begin' directives inside an exclusion and 'exclude-end'
+// directives outside of an exclusion should have no effect.
+console.log(
+  D[0],
+  // datadog-privacy-allowlist-exclude-end
+  D[0],
+  // datadog-privacy-allowlist-exclude-begin
+  "exclude range with extra directives 1",
+  'exclude range with extra directives 2',
+  // datadog-privacy-allowlist-exclude-begin
+  \`exclude range with extra directives 3\`,
+  tag\`exclude range with extra directives 4\`,
+  // datadog-privacy-allowlist-exclude-end
+  D[0],
+);
+
+// An unterminated 'exclude-begin' should cover the rest of the file. (And extra
+// 'exclude-begins' after that point should be ignored.)
+console.log(
+  D[0],
+  /* datadog-privacy-allowlist-exclude-begin */
+  "exclude range with unterminated comment 1",
+  'exclude range with unterminated comment 2',
+  /* datadog-privacy-allowlist-exclude-begin */
+  \`exclude range with unterminated comment 3\`,
+  tag\`exclude range with unterminated comment 4\`,
+);
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIiwiIl0sInNvdXJjZXNDb250ZW50IjpbImNvbnN0IHRhZyA9ICgpID0+IHsgfTtcblxuLy8gU2hvdWxkIGJlIGFibGUgdG8gZXhjbHVkZSBhbnkga2luZCBvZiBzdHJpbmcgd2l0aCBhbiBleGNsdWRlLWxpbmUuXG5jb25zb2xlLmxvZyhcbiAgJ25vdCBleGNsdWRlZCcsXG4gIFwiZXhjbHVkZSBsaW5lIDFcIiwgLy8gZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmVcbiAgJ25vdCBleGNsdWRlZCcsXG4gICdleGNsdWRlIGxpbmUgMicsIC8vIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1saW5lXG4gICdub3QgZXhjbHVkZWQnLFxuICBgZXhjbHVkZSBsaW5lIDNgLCAvLyBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtbGluZVxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgdGFnYGV4Y2x1ZGUgbGluZSA0YCwgLy8gZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmVcbiAgJ25vdCBleGNsdWRlZCcsXG4pO1xuXG4vLyBCbG9jayBjb21tZW50cyBzaG91bGQgYWxzbyB3b3JrLlxuY29uc29sZS5sb2coXG4gICdub3QgZXhjbHVkZWQnLFxuICBcImJsb2NrIDFcIiwgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmUgKi9cbiAgJ25vdCBleGNsdWRlZCcsXG4gICdibG9jayAyJywgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmUgKi9cbiAgJ25vdCBleGNsdWRlZCcsXG4gIGBibG9jayAzYCwgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmUgKi9cbiAgJ25vdCBleGNsdWRlZCcsXG4gIHRhZ2BibG9jayA0YCwgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmUgKi9cbiAgJ25vdCBleGNsdWRlZCcsXG4pO1xuXG4vLyBQcmVmaXhlZCBibG9jayBjb21tZW50cyBzaG91bGQgYWxzbyB3b3JrLlxuY29uc29sZS5sb2coXG4gICdub3QgZXhjbHVkZWQnLFxuICAvKiBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtbGluZSAqLyBcInByZWZpeGVkIGJsb2NrIDFcIixcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8qIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1saW5lICovICdwcmVmaXhlZCBibG9jayAyJyxcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8qIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1saW5lICovIGBwcmVmaXhlZCBibG9jayAzYCxcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8qIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1saW5lICovIHRhZ2BwcmVmaXhlZCBibG9jayA0YCxcbiAgJ25vdCBleGNsdWRlZCcsXG4pO1xuXG4vLyBNdWx0aWxpbmUgYmxvY2sgY29tbWVudHMgc2hvdWxkIGFsc28gd29yay5cbmNvbnNvbGUubG9nKFxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgLypcbiAgIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1saW5lXG4gICAqLyBcIm11bHRpbGluZSBibG9jayAxXCIsXG4gICdub3QgZXhjbHVkZWQnLFxuICAvKlxuICAgZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmVcbiAgICovICdtdWx0aWxpbmUgYmxvY2sgMicsXG4gICdub3QgZXhjbHVkZWQnLFxuICAvKlxuICAgZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmVcbiAgICovIGBtdWx0aWxpbmUgYmxvY2sgM2AsXG4gICdub3QgZXhjbHVkZWQnLFxuICAvKlxuICAgZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmVcbiAgICovIHRhZ2BtdWx0aWxpbmUgYmxvY2sgNGAsXG4gICdub3QgZXhjbHVkZWQnLFxuKTtcblxuLy8gU2hvdWxkIGJlIGFibGUgdG8gZXhjbHVkZSBhbnkga2luZCBvZiBzdHJpbmcgd2l0aCBhbiBleGNsdWRlLW5leHQtbGluZS5cbmNvbnNvbGUubG9nKFxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgLy8gZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLW5leHQtbGluZVxuICBcImV4Y2x1ZGUgbmV4dCBsaW5lIDFcIixcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8vIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1uZXh0LWxpbmVcbiAgJ2V4Y2x1ZGUgbmV4dCBsaW5lIDInLFxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgLy8gZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLW5leHQtbGluZVxuICBgZXhjbHVkZSBuZXh0IGxpbmUgM2AsXG4gICdub3QgZXhjbHVkZWQnLFxuICAvLyBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtbmV4dC1saW5lXG4gIHRhZ2BleGNsdWRlIG5leHQgbGluZSA0YCxcbiAgJ25vdCBleGNsdWRlZCcsXG4pO1xuXG4vLyBCbG9jayBjb21tZW50cyBzaG91bGQgYWxzbyB3b3JrIGZvciBleGNsdWRlLW5leHQtbGluZS5cbmNvbnNvbGUubG9nKFxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLW5leHQtbGluZSAqL1xuICBcImV4Y2x1ZGUgbmV4dCBsaW5lIGJsb2NrIDFcIixcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8qIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1uZXh0LWxpbmUgKi9cbiAgJ2V4Y2x1ZGUgbmV4dCBsaW5lIGJsb2NrIDInLFxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLW5leHQtbGluZSAqL1xuICBgZXhjbHVkZSBuZXh0IGxpbmUgYmxvY2sgM2AsXG4gICdub3QgZXhjbHVkZWQnLFxuICAvKiBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtbmV4dC1saW5lICovXG4gIHRhZ2BleGNsdWRlIG5leHQgbGluZSBibG9jayA0YCxcbiAgJ25vdCBleGNsdWRlZCcsXG4pO1xuXG4vLyBNdWx0aWxpbmUgYmxvY2sgY29tbWVudHMgc2hvdWxkIGFsc28gd29yayBmb3IgZXhjbHVkZS1uZXh0LWxpbmUuXG5jb25zb2xlLmxvZyhcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8qXG4gICBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtbmV4dC1saW5lXG4gICAqL1xuICBcImV4Y2x1ZGUgbmV4dCBsaW5lIG11bHRpbGluZSBibG9jayAxXCIsXG4gICdub3QgZXhjbHVkZWQnLFxuICAvKlxuICAgZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLW5leHQtbGluZVxuICAgKi9cbiAgJ2V4Y2x1ZGUgbmV4dCBsaW5lIG11bHRpbGluZSBibG9jayAyJyxcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8qXG4gICBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtbmV4dC1saW5lXG4gICAqL1xuICBgZXhjbHVkZSBuZXh0IGxpbmUgbXVsdGlsaW5lIGJsb2NrIDNgLFxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgLypcbiAgIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1uZXh0LWxpbmVcbiAgICovXG4gIHRhZ2BleGNsdWRlIG5leHQgbGluZSBtdWx0aWxpbmUgYmxvY2sgNGAsXG4gICdub3QgZXhjbHVkZWQnLFxuKTtcblxuLy8gV2Ugc2hvdWxkIGJlIGFibGUgdG8gZXhjbHVkZSBhIHJhbmdlIG9mIGxpbmVzLlxuY29uc29sZS5sb2coXG4gICdub3QgZXhjbHVkZWQnLFxuICAvLyBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtYmVnaW5cbiAgXCJleGNsdWRlIHJhbmdlIDFcIixcbiAgJ2V4Y2x1ZGUgcmFuZ2UgMicsXG4gIGBleGNsdWRlIHJhbmdlIDNgLFxuICB0YWdgZXhjbHVkZSByYW5nZSA0YCxcbiAgLy8gZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWVuZFxuICAnbm90IGV4Y2x1ZGVkJyxcbik7XG5cbi8vIFdlIHNob3VsZCBiZSBhYmxlIHRvIGV4Y2x1ZGUgYSByYW5nZSBvZiB3aXRoIGEgYmxvY2sgY29tbWVudC5cbmNvbnNvbGUubG9nKFxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWJlZ2luICovXG4gIFwiZXhjbHVkZSByYW5nZSB3aXRoIGJsb2NrIGNvbW1lbnQgMVwiLFxuICAnZXhjbHVkZSByYW5nZSB3aXRoIGJsb2NrIGNvbW1lbnQgMicsXG4gIGBleGNsdWRlIHJhbmdlIHdpdGggYmxvY2sgY29tbWVudCAzYCxcbiAgdGFnYGV4Y2x1ZGUgcmFuZ2Ugd2l0aCBibG9jayBjb21tZW50IDRgLFxuICAvKiBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtZW5kICovXG4gICdub3QgZXhjbHVkZWQnLFxuKTtcblxuLy8gRXh0cmEgJ2V4Y2x1ZGUtYmVnaW4nIGRpcmVjdGl2ZXMgaW5zaWRlIGFuIGV4Y2x1c2lvbiBhbmQgJ2V4Y2x1ZGUtZW5kJ1xuLy8gZGlyZWN0aXZlcyBvdXRzaWRlIG9mIGFuIGV4Y2x1c2lvbiBzaG91bGQgaGF2ZSBubyBlZmZlY3QuXG5jb25zb2xlLmxvZyhcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8vIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1lbmRcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8vIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1iZWdpblxuICBcImV4Y2x1ZGUgcmFuZ2Ugd2l0aCBleHRyYSBkaXJlY3RpdmVzIDFcIixcbiAgJ2V4Y2x1ZGUgcmFuZ2Ugd2l0aCBleHRyYSBkaXJlY3RpdmVzIDInLFxuICAvLyBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtYmVnaW5cbiAgYGV4Y2x1ZGUgcmFuZ2Ugd2l0aCBleHRyYSBkaXJlY3RpdmVzIDNgLFxuICB0YWdgZXhjbHVkZSByYW5nZSB3aXRoIGV4dHJhIGRpcmVjdGl2ZXMgNGAsXG4gIC8vIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1lbmRcbiAgJ25vdCBleGNsdWRlZCcsXG4pO1xuXG4vLyBBbiB1bnRlcm1pbmF0ZWQgJ2V4Y2x1ZGUtYmVnaW4nIHNob3VsZCBjb3ZlciB0aGUgcmVzdCBvZiB0aGUgZmlsZS4gKEFuZCBleHRyYVxuLy8gJ2V4Y2x1ZGUtYmVnaW5zJyBhZnRlciB0aGF0IHBvaW50IHNob3VsZCBiZSBpZ25vcmVkLilcbmNvbnNvbGUubG9nKFxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWJlZ2luICovXG4gIFwiZXhjbHVkZSByYW5nZSB3aXRoIHVudGVybWluYXRlZCBjb21tZW50IDFcIixcbiAgJ2V4Y2x1ZGUgcmFuZ2Ugd2l0aCB1bnRlcm1pbmF0ZWQgY29tbWVudCAyJyxcbiAgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWJlZ2luICovXG4gIGBleGNsdWRlIHJhbmdlIHdpdGggdW50ZXJtaW5hdGVkIGNvbW1lbnQgM2AsXG4gIHRhZ2BleGNsdWRlIHJhbmdlIHdpdGggdW50ZXJtaW5hdGVkIGNvbW1lbnQgNGAsXG4pO1xuIiwiIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7Ozs7QUFBQSxNQUFNLEdBQUcsR0FBRyxNQUFNO0FBQ2xCO0FBQ0E7QUFDQSxPQUFPLENBQUMsR0FBRztBQUNYLEVBQUUsSUFBYztBQUNoQixFQUFFLGdCQUFnQjtBQUNsQixFQUFFLElBQWM7QUFDaEIsRUFBRSxnQkFBZ0I7QUFDbEIsRUFBRSxJQUFjO0FBQ2hCLEdBQUcsY0FBYztBQUNqQixFQUFFLElBQWM7QUFDaEIsRUFBRSxHQUFHLENBQUMsY0FBYztBQUNwQixFQUFFLElBQWM7QUFDaEI7QUFDQTtBQUNBO0FBQ0EsT0FBTyxDQUFDLEdBQUc7QUFDWCxFQUFFLElBQWM7QUFDaEIsRUFBRSxTQUFTO0FBQ1gsRUFBRSxJQUFjO0FBQ2hCLEVBQUUsU0FBUztBQUNYLEVBQUUsSUFBYztBQUNoQixHQUFHLE9BQU87QUFDVixFQUFFLElBQWM7QUFDaEIsRUFBRSxHQUFHLENBQUMsT0FBTztBQUNiLEVBQUUsSUFBYztBQUNoQjtBQUNBO0FBQ0E7QUFDQSxPQUFPLENBQUMsR0FBRztBQUNYLEVBQUUsSUFBYztBQUNoQiwrQ0FBK0Msa0JBQWtCO0FBQ2pFLEVBQUUsSUFBYztBQUNoQiwrQ0FBK0Msa0JBQWtCO0FBQ2pFLEVBQUUsSUFBYztBQUNoQixnREFBZ0QsZ0JBQWdCO0FBQ2hFLEVBQUUsSUFBYztBQUNoQiwrQ0FBK0MsR0FBRyxDQUFDLGdCQUFnQjtBQUNuRSxFQUFFLElBQWM7QUFDaEI7QUFDQTtBQUNBO0FBQ0EsT0FBTyxDQUFDLEdBQUc7QUFDWCxFQUFFLElBQWM7QUFDaEI7QUFDQTtBQUNBLE1BQU0sbUJBQW1CO0FBQ3pCLEVBQUUsSUFBYztBQUNoQjtBQUNBO0FBQ0EsTUFBTSxtQkFBbUI7QUFDekIsRUFBRSxJQUFjO0FBQ2hCO0FBQ0E7QUFDQSxPQUFPLGlCQUFpQjtBQUN4QixFQUFFLElBQWM7QUFDaEI7QUFDQTtBQUNBLE1BQU0sR0FBRyxDQUFDLGlCQUFpQjtBQUMzQixFQUFFLElBQWM7QUFDaEI7QUFDQTtBQUNBO0FBQ0EsT0FBTyxDQUFDLEdBQUc7QUFDWCxFQUFFLElBQWM7QUFDaEI7QUFDQSxFQUFFLHFCQUFxQjtBQUN2QixFQUFFLElBQWM7QUFDaEI7QUFDQSxFQUFFLHFCQUFxQjtBQUN2QixFQUFFLElBQWM7QUFDaEI7QUFDQSxHQUFHLG1CQUFtQjtBQUN0QixFQUFFLElBQWM7QUFDaEI7QUFDQSxFQUFFLEdBQUcsQ0FBQyxtQkFBbUI7QUFDekIsRUFBRSxJQUFjO0FBQ2hCO0FBQ0E7QUFDQTtBQUNBLE9BQU8sQ0FBQyxHQUFHO0FBQ1gsRUFBRSxJQUFjO0FBQ2hCO0FBQ0EsRUFBRSwyQkFBMkI7QUFDN0IsRUFBRSxJQUFjO0FBQ2hCO0FBQ0EsRUFBRSwyQkFBMkI7QUFDN0IsRUFBRSxJQUFjO0FBQ2hCO0FBQ0EsR0FBRyx5QkFBeUI7QUFDNUIsRUFBRSxJQUFjO0FBQ2hCO0FBQ0EsRUFBRSxHQUFHLENBQUMseUJBQXlCO0FBQy9CLEVBQUUsSUFBYztBQUNoQjtBQUNBO0FBQ0E7QUFDQSxPQUFPLENBQUMsR0FBRztBQUNYLEVBQUUsSUFBYztBQUNoQjtBQUNBO0FBQ0E7QUFDQSxFQUFFLHFDQUFxQztBQUN2QyxFQUFFLElBQWM7QUFDaEI7QUFDQTtBQUNBO0FBQ0EsRUFBRSxxQ0FBcUM7QUFDdkMsRUFBRSxJQUFjO0FBQ2hCO0FBQ0E7QUFDQTtBQUNBLEdBQUcsbUNBQW1DO0FBQ3RDLEVBQUUsSUFBYztBQUNoQjtBQUNBO0FBQ0E7QUFDQSxFQUFFLEdBQUcsQ0FBQyxtQ0FBbUM7QUFDekMsRUFBRSxJQUFjO0FBQ2hCO0FBQ0E7QUFDQTtBQUNBLE9BQU8sQ0FBQyxHQUFHO0FBQ1gsRUFBRSxJQUFjO0FBQ2hCO0FBQ0EsRUFBRSxpQkFBaUI7QUFDbkIsRUFBRSxpQkFBaUI7QUFDbkIsR0FBRyxlQUFlO0FBQ2xCLEVBQUUsR0FBRyxDQUFDLGVBQWU7QUFDckI7QUFDQSxFQUFFLElBQWM7QUFDaEI7QUFDQTtBQUNBO0FBQ0EsT0FBTyxDQUFDLEdBQUc7QUFDWCxFQUFFLElBQWM7QUFDaEI7QUFDQSxFQUFFLG9DQUFvQztBQUN0QyxFQUFFLG9DQUFvQztBQUN0QyxHQUFHLGtDQUFrQztBQUNyQyxFQUFFLEdBQUcsQ0FBQyxrQ0FBa0M7QUFDeEM7QUFDQSxFQUFFLElBQWM7QUFDaEI7QUFDQTtBQUNBO0FBQ0E7QUFDQSxPQUFPLENBQUMsR0FBRztBQUNYLEVBQUUsSUFBYztBQUNoQjtBQUNBLEVBQUUsSUFBYztBQUNoQjtBQUNBLEVBQUUsdUNBQXVDO0FBQ3pDLEVBQUUsdUNBQXVDO0FBQ3pDO0FBQ0EsR0FBRyxxQ0FBcUM7QUFDeEMsRUFBRSxHQUFHLENBQUMscUNBQXFDO0FBQzNDO0FBQ0EsRUFBRSxJQUFjO0FBQ2hCO0FBQ0E7QUFDQTtBQUNBO0FBQ0EsT0FBTyxDQUFDLEdBQUc7QUFDWCxFQUFFLElBQWM7QUFDaEI7QUFDQSxFQUFFLDJDQUEyQztBQUM3QyxFQUFFLDJDQUEyQztBQUM3QztBQUNBLEdBQUcseUNBQXlDO0FBQzVDLEVBQUUsR0FBRyxDQUFDLHlDQUF5QztBQUMvQyIsImlnbm9yZUxpc3QiOlsxXX0="
+`;
+
 exports[`the CJS version should transform code correctly > for excluded-strings 1`] = `
 "// URLS (excluded by URL_STRINGS_REGEX):
 console.log(
@@ -1913,6 +2486,197 @@ const $ = 123;
 const D = 456;
 console.log(/* (attached comment) */ A[0]);
 //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIiwiIl0sInNvdXJjZXNDb250ZW50IjpbIi8vIENyZWF0ZSBjb25mbGljdGluZyBiaW5kaW5ncyBmb3IgdGhlIGRlZmF1bHQgbmFtZXMgb2YgdGhlIGhlbHBlcnMuXG5jb25zdCAkID0gMTIzO1xuY29uc3QgRCA9IDQ1NjtcbmNvbnNvbGUubG9nKC8qIChhdHRhY2hlZCBjb21tZW50KSAqLyBcInRlc3RcIik7XG4iLCIiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6Ijs7OztBQUFBO0FBQ0EsTUFBTSxDQUFDLEdBQUc7QUFDVixNQUFNLENBQUMsR0FBRztBQUNWLE9BQU8sQ0FBQyxHQUFHLDBCQUEwQixJQUFNIiwiaWdub3JlTGlzdCI6WzFdfQ=="
+`;
+
+exports[`the ESM version should transform code correctly > for excluded-file 1`] = `
+"// datadog-privacy-allowlist-exclude-file
+console.log(
+  "Should",
+  'not',
+  \`be\`,
+  "allowlisted"
+);
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIiwiIl0sInNvdXJjZXNDb250ZW50IjpbIi8vIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1maWxlXG5jb25zb2xlLmxvZyhcbiAgXCJTaG91bGRcIixcbiAgJ25vdCcsXG4gIGBiZWAsXG4gIFwiYWxsb3dsaXN0ZWRcIlxuKTtcbiIsIiJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQTtBQUNBLE9BQU8sQ0FBQyxHQUFHO0FBQ1gsRUFBRSxRQUFRO0FBQ1YsRUFBRSxLQUFLO0FBQ1AsR0FBRyxFQUFFO0FBQ0wsRUFBRSxhQUFhO0FBQ2YiLCJpZ25vcmVMaXN0IjpbMV19"
+`;
+
+exports[`the ESM version should transform code correctly > for excluded-lines 1`] = `
+"import { $ } from ' datadog:privacy-helpers.mjs';
+const D = $([
+  'not excluded',
+]);
+const tag = () => { };
+
+// Should be able to exclude any kind of string with an exclude-line.
+console.log(
+  D[0],
+  "exclude line 1", // datadog-privacy-allowlist-exclude-line
+  D[0],
+  'exclude line 2', // datadog-privacy-allowlist-exclude-line
+  D[0],
+  \`exclude line 3\`, // datadog-privacy-allowlist-exclude-line
+  D[0],
+  tag\`exclude line 4\`, // datadog-privacy-allowlist-exclude-line
+  D[0],
+);
+
+// Block comments should also work.
+console.log(
+  D[0],
+  "block 1", /* datadog-privacy-allowlist-exclude-line */
+  D[0],
+  'block 2', /* datadog-privacy-allowlist-exclude-line */
+  D[0],
+  \`block 3\`, /* datadog-privacy-allowlist-exclude-line */
+  D[0],
+  tag\`block 4\`, /* datadog-privacy-allowlist-exclude-line */
+  D[0],
+);
+
+// Prefixed block comments should also work.
+console.log(
+  D[0],
+  /* datadog-privacy-allowlist-exclude-line */ "prefixed block 1",
+  D[0],
+  /* datadog-privacy-allowlist-exclude-line */ 'prefixed block 2',
+  D[0],
+  /* datadog-privacy-allowlist-exclude-line */ \`prefixed block 3\`,
+  D[0],
+  /* datadog-privacy-allowlist-exclude-line */ tag\`prefixed block 4\`,
+  D[0],
+);
+
+// Multiline block comments should also work.
+console.log(
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-line
+   */ "multiline block 1",
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-line
+   */ 'multiline block 2',
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-line
+   */ \`multiline block 3\`,
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-line
+   */ tag\`multiline block 4\`,
+  D[0],
+);
+
+// Should be able to exclude any kind of string with an exclude-next-line.
+console.log(
+  D[0],
+  // datadog-privacy-allowlist-exclude-next-line
+  "exclude next line 1",
+  D[0],
+  // datadog-privacy-allowlist-exclude-next-line
+  'exclude next line 2',
+  D[0],
+  // datadog-privacy-allowlist-exclude-next-line
+  \`exclude next line 3\`,
+  D[0],
+  // datadog-privacy-allowlist-exclude-next-line
+  tag\`exclude next line 4\`,
+  D[0],
+);
+
+// Block comments should also work for exclude-next-line.
+console.log(
+  D[0],
+  /* datadog-privacy-allowlist-exclude-next-line */
+  "exclude next line block 1",
+  D[0],
+  /* datadog-privacy-allowlist-exclude-next-line */
+  'exclude next line block 2',
+  D[0],
+  /* datadog-privacy-allowlist-exclude-next-line */
+  \`exclude next line block 3\`,
+  D[0],
+  /* datadog-privacy-allowlist-exclude-next-line */
+  tag\`exclude next line block 4\`,
+  D[0],
+);
+
+// Multiline block comments should also work for exclude-next-line.
+console.log(
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-next-line
+   */
+  "exclude next line multiline block 1",
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-next-line
+   */
+  'exclude next line multiline block 2',
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-next-line
+   */
+  \`exclude next line multiline block 3\`,
+  D[0],
+  /*
+   datadog-privacy-allowlist-exclude-next-line
+   */
+  tag\`exclude next line multiline block 4\`,
+  D[0],
+);
+
+// We should be able to exclude a range of lines.
+console.log(
+  D[0],
+  // datadog-privacy-allowlist-exclude-begin
+  "exclude range 1",
+  'exclude range 2',
+  \`exclude range 3\`,
+  tag\`exclude range 4\`,
+  // datadog-privacy-allowlist-exclude-end
+  D[0],
+);
+
+// We should be able to exclude a range of with a block comment.
+console.log(
+  D[0],
+  /* datadog-privacy-allowlist-exclude-begin */
+  "exclude range with block comment 1",
+  'exclude range with block comment 2',
+  \`exclude range with block comment 3\`,
+  tag\`exclude range with block comment 4\`,
+  /* datadog-privacy-allowlist-exclude-end */
+  D[0],
+);
+
+// Extra 'exclude-begin' directives inside an exclusion and 'exclude-end'
+// directives outside of an exclusion should have no effect.
+console.log(
+  D[0],
+  // datadog-privacy-allowlist-exclude-end
+  D[0],
+  // datadog-privacy-allowlist-exclude-begin
+  "exclude range with extra directives 1",
+  'exclude range with extra directives 2',
+  // datadog-privacy-allowlist-exclude-begin
+  \`exclude range with extra directives 3\`,
+  tag\`exclude range with extra directives 4\`,
+  // datadog-privacy-allowlist-exclude-end
+  D[0],
+);
+
+// An unterminated 'exclude-begin' should cover the rest of the file. (And extra
+// 'exclude-begins' after that point should be ignored.)
+console.log(
+  D[0],
+  /* datadog-privacy-allowlist-exclude-begin */
+  "exclude range with unterminated comment 1",
+  'exclude range with unterminated comment 2',
+  /* datadog-privacy-allowlist-exclude-begin */
+  \`exclude range with unterminated comment 3\`,
+  tag\`exclude range with unterminated comment 4\`,
+);
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIiwiIl0sInNvdXJjZXNDb250ZW50IjpbImNvbnN0IHRhZyA9ICgpID0+IHsgfTtcblxuLy8gU2hvdWxkIGJlIGFibGUgdG8gZXhjbHVkZSBhbnkga2luZCBvZiBzdHJpbmcgd2l0aCBhbiBleGNsdWRlLWxpbmUuXG5jb25zb2xlLmxvZyhcbiAgJ25vdCBleGNsdWRlZCcsXG4gIFwiZXhjbHVkZSBsaW5lIDFcIiwgLy8gZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmVcbiAgJ25vdCBleGNsdWRlZCcsXG4gICdleGNsdWRlIGxpbmUgMicsIC8vIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1saW5lXG4gICdub3QgZXhjbHVkZWQnLFxuICBgZXhjbHVkZSBsaW5lIDNgLCAvLyBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtbGluZVxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgdGFnYGV4Y2x1ZGUgbGluZSA0YCwgLy8gZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmVcbiAgJ25vdCBleGNsdWRlZCcsXG4pO1xuXG4vLyBCbG9jayBjb21tZW50cyBzaG91bGQgYWxzbyB3b3JrLlxuY29uc29sZS5sb2coXG4gICdub3QgZXhjbHVkZWQnLFxuICBcImJsb2NrIDFcIiwgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmUgKi9cbiAgJ25vdCBleGNsdWRlZCcsXG4gICdibG9jayAyJywgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmUgKi9cbiAgJ25vdCBleGNsdWRlZCcsXG4gIGBibG9jayAzYCwgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmUgKi9cbiAgJ25vdCBleGNsdWRlZCcsXG4gIHRhZ2BibG9jayA0YCwgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmUgKi9cbiAgJ25vdCBleGNsdWRlZCcsXG4pO1xuXG4vLyBQcmVmaXhlZCBibG9jayBjb21tZW50cyBzaG91bGQgYWxzbyB3b3JrLlxuY29uc29sZS5sb2coXG4gICdub3QgZXhjbHVkZWQnLFxuICAvKiBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtbGluZSAqLyBcInByZWZpeGVkIGJsb2NrIDFcIixcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8qIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1saW5lICovICdwcmVmaXhlZCBibG9jayAyJyxcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8qIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1saW5lICovIGBwcmVmaXhlZCBibG9jayAzYCxcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8qIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1saW5lICovIHRhZ2BwcmVmaXhlZCBibG9jayA0YCxcbiAgJ25vdCBleGNsdWRlZCcsXG4pO1xuXG4vLyBNdWx0aWxpbmUgYmxvY2sgY29tbWVudHMgc2hvdWxkIGFsc28gd29yay5cbmNvbnNvbGUubG9nKFxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgLypcbiAgIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1saW5lXG4gICAqLyBcIm11bHRpbGluZSBibG9jayAxXCIsXG4gICdub3QgZXhjbHVkZWQnLFxuICAvKlxuICAgZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmVcbiAgICovICdtdWx0aWxpbmUgYmxvY2sgMicsXG4gICdub3QgZXhjbHVkZWQnLFxuICAvKlxuICAgZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmVcbiAgICovIGBtdWx0aWxpbmUgYmxvY2sgM2AsXG4gICdub3QgZXhjbHVkZWQnLFxuICAvKlxuICAgZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWxpbmVcbiAgICovIHRhZ2BtdWx0aWxpbmUgYmxvY2sgNGAsXG4gICdub3QgZXhjbHVkZWQnLFxuKTtcblxuLy8gU2hvdWxkIGJlIGFibGUgdG8gZXhjbHVkZSBhbnkga2luZCBvZiBzdHJpbmcgd2l0aCBhbiBleGNsdWRlLW5leHQtbGluZS5cbmNvbnNvbGUubG9nKFxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgLy8gZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLW5leHQtbGluZVxuICBcImV4Y2x1ZGUgbmV4dCBsaW5lIDFcIixcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8vIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1uZXh0LWxpbmVcbiAgJ2V4Y2x1ZGUgbmV4dCBsaW5lIDInLFxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgLy8gZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLW5leHQtbGluZVxuICBgZXhjbHVkZSBuZXh0IGxpbmUgM2AsXG4gICdub3QgZXhjbHVkZWQnLFxuICAvLyBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtbmV4dC1saW5lXG4gIHRhZ2BleGNsdWRlIG5leHQgbGluZSA0YCxcbiAgJ25vdCBleGNsdWRlZCcsXG4pO1xuXG4vLyBCbG9jayBjb21tZW50cyBzaG91bGQgYWxzbyB3b3JrIGZvciBleGNsdWRlLW5leHQtbGluZS5cbmNvbnNvbGUubG9nKFxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLW5leHQtbGluZSAqL1xuICBcImV4Y2x1ZGUgbmV4dCBsaW5lIGJsb2NrIDFcIixcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8qIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1uZXh0LWxpbmUgKi9cbiAgJ2V4Y2x1ZGUgbmV4dCBsaW5lIGJsb2NrIDInLFxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLW5leHQtbGluZSAqL1xuICBgZXhjbHVkZSBuZXh0IGxpbmUgYmxvY2sgM2AsXG4gICdub3QgZXhjbHVkZWQnLFxuICAvKiBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtbmV4dC1saW5lICovXG4gIHRhZ2BleGNsdWRlIG5leHQgbGluZSBibG9jayA0YCxcbiAgJ25vdCBleGNsdWRlZCcsXG4pO1xuXG4vLyBNdWx0aWxpbmUgYmxvY2sgY29tbWVudHMgc2hvdWxkIGFsc28gd29yayBmb3IgZXhjbHVkZS1uZXh0LWxpbmUuXG5jb25zb2xlLmxvZyhcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8qXG4gICBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtbmV4dC1saW5lXG4gICAqL1xuICBcImV4Y2x1ZGUgbmV4dCBsaW5lIG11bHRpbGluZSBibG9jayAxXCIsXG4gICdub3QgZXhjbHVkZWQnLFxuICAvKlxuICAgZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLW5leHQtbGluZVxuICAgKi9cbiAgJ2V4Y2x1ZGUgbmV4dCBsaW5lIG11bHRpbGluZSBibG9jayAyJyxcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8qXG4gICBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtbmV4dC1saW5lXG4gICAqL1xuICBgZXhjbHVkZSBuZXh0IGxpbmUgbXVsdGlsaW5lIGJsb2NrIDNgLFxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgLypcbiAgIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1uZXh0LWxpbmVcbiAgICovXG4gIHRhZ2BleGNsdWRlIG5leHQgbGluZSBtdWx0aWxpbmUgYmxvY2sgNGAsXG4gICdub3QgZXhjbHVkZWQnLFxuKTtcblxuLy8gV2Ugc2hvdWxkIGJlIGFibGUgdG8gZXhjbHVkZSBhIHJhbmdlIG9mIGxpbmVzLlxuY29uc29sZS5sb2coXG4gICdub3QgZXhjbHVkZWQnLFxuICAvLyBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtYmVnaW5cbiAgXCJleGNsdWRlIHJhbmdlIDFcIixcbiAgJ2V4Y2x1ZGUgcmFuZ2UgMicsXG4gIGBleGNsdWRlIHJhbmdlIDNgLFxuICB0YWdgZXhjbHVkZSByYW5nZSA0YCxcbiAgLy8gZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWVuZFxuICAnbm90IGV4Y2x1ZGVkJyxcbik7XG5cbi8vIFdlIHNob3VsZCBiZSBhYmxlIHRvIGV4Y2x1ZGUgYSByYW5nZSBvZiB3aXRoIGEgYmxvY2sgY29tbWVudC5cbmNvbnNvbGUubG9nKFxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWJlZ2luICovXG4gIFwiZXhjbHVkZSByYW5nZSB3aXRoIGJsb2NrIGNvbW1lbnQgMVwiLFxuICAnZXhjbHVkZSByYW5nZSB3aXRoIGJsb2NrIGNvbW1lbnQgMicsXG4gIGBleGNsdWRlIHJhbmdlIHdpdGggYmxvY2sgY29tbWVudCAzYCxcbiAgdGFnYGV4Y2x1ZGUgcmFuZ2Ugd2l0aCBibG9jayBjb21tZW50IDRgLFxuICAvKiBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtZW5kICovXG4gICdub3QgZXhjbHVkZWQnLFxuKTtcblxuLy8gRXh0cmEgJ2V4Y2x1ZGUtYmVnaW4nIGRpcmVjdGl2ZXMgaW5zaWRlIGFuIGV4Y2x1c2lvbiBhbmQgJ2V4Y2x1ZGUtZW5kJ1xuLy8gZGlyZWN0aXZlcyBvdXRzaWRlIG9mIGFuIGV4Y2x1c2lvbiBzaG91bGQgaGF2ZSBubyBlZmZlY3QuXG5jb25zb2xlLmxvZyhcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8vIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1lbmRcbiAgJ25vdCBleGNsdWRlZCcsXG4gIC8vIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1iZWdpblxuICBcImV4Y2x1ZGUgcmFuZ2Ugd2l0aCBleHRyYSBkaXJlY3RpdmVzIDFcIixcbiAgJ2V4Y2x1ZGUgcmFuZ2Ugd2l0aCBleHRyYSBkaXJlY3RpdmVzIDInLFxuICAvLyBkYXRhZG9nLXByaXZhY3ktYWxsb3dsaXN0LWV4Y2x1ZGUtYmVnaW5cbiAgYGV4Y2x1ZGUgcmFuZ2Ugd2l0aCBleHRyYSBkaXJlY3RpdmVzIDNgLFxuICB0YWdgZXhjbHVkZSByYW5nZSB3aXRoIGV4dHJhIGRpcmVjdGl2ZXMgNGAsXG4gIC8vIGRhdGFkb2ctcHJpdmFjeS1hbGxvd2xpc3QtZXhjbHVkZS1lbmRcbiAgJ25vdCBleGNsdWRlZCcsXG4pO1xuXG4vLyBBbiB1bnRlcm1pbmF0ZWQgJ2V4Y2x1ZGUtYmVnaW4nIHNob3VsZCBjb3ZlciB0aGUgcmVzdCBvZiB0aGUgZmlsZS4gKEFuZCBleHRyYVxuLy8gJ2V4Y2x1ZGUtYmVnaW5zJyBhZnRlciB0aGF0IHBvaW50IHNob3VsZCBiZSBpZ25vcmVkLilcbmNvbnNvbGUubG9nKFxuICAnbm90IGV4Y2x1ZGVkJyxcbiAgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWJlZ2luICovXG4gIFwiZXhjbHVkZSByYW5nZSB3aXRoIHVudGVybWluYXRlZCBjb21tZW50IDFcIixcbiAgJ2V4Y2x1ZGUgcmFuZ2Ugd2l0aCB1bnRlcm1pbmF0ZWQgY29tbWVudCAyJyxcbiAgLyogZGF0YWRvZy1wcml2YWN5LWFsbG93bGlzdC1leGNsdWRlLWJlZ2luICovXG4gIGBleGNsdWRlIHJhbmdlIHdpdGggdW50ZXJtaW5hdGVkIGNvbW1lbnQgM2AsXG4gIHRhZ2BleGNsdWRlIHJhbmdlIHdpdGggdW50ZXJtaW5hdGVkIGNvbW1lbnQgNGAsXG4pO1xuIiwiIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7Ozs7QUFBQSxNQUFNLEdBQUcsR0FBRyxNQUFNO0FBQ2xCO0FBQ0E7QUFDQSxPQUFPLENBQUMsR0FBRztBQUNYLEVBQUUsSUFBYztBQUNoQixFQUFFLGdCQUFnQjtBQUNsQixFQUFFLElBQWM7QUFDaEIsRUFBRSxnQkFBZ0I7QUFDbEIsRUFBRSxJQUFjO0FBQ2hCLEdBQUcsY0FBYztBQUNqQixFQUFFLElBQWM7QUFDaEIsRUFBRSxHQUFHLENBQUMsY0FBYztBQUNwQixFQUFFLElBQWM7QUFDaEI7QUFDQTtBQUNBO0FBQ0EsT0FBTyxDQUFDLEdBQUc7QUFDWCxFQUFFLElBQWM7QUFDaEIsRUFBRSxTQUFTO0FBQ1gsRUFBRSxJQUFjO0FBQ2hCLEVBQUUsU0FBUztBQUNYLEVBQUUsSUFBYztBQUNoQixHQUFHLE9BQU87QUFDVixFQUFFLElBQWM7QUFDaEIsRUFBRSxHQUFHLENBQUMsT0FBTztBQUNiLEVBQUUsSUFBYztBQUNoQjtBQUNBO0FBQ0E7QUFDQSxPQUFPLENBQUMsR0FBRztBQUNYLEVBQUUsSUFBYztBQUNoQiwrQ0FBK0Msa0JBQWtCO0FBQ2pFLEVBQUUsSUFBYztBQUNoQiwrQ0FBK0Msa0JBQWtCO0FBQ2pFLEVBQUUsSUFBYztBQUNoQixnREFBZ0QsZ0JBQWdCO0FBQ2hFLEVBQUUsSUFBYztBQUNoQiwrQ0FBK0MsR0FBRyxDQUFDLGdCQUFnQjtBQUNuRSxFQUFFLElBQWM7QUFDaEI7QUFDQTtBQUNBO0FBQ0EsT0FBTyxDQUFDLEdBQUc7QUFDWCxFQUFFLElBQWM7QUFDaEI7QUFDQTtBQUNBLE1BQU0sbUJBQW1CO0FBQ3pCLEVBQUUsSUFBYztBQUNoQjtBQUNBO0FBQ0EsTUFBTSxtQkFBbUI7QUFDekIsRUFBRSxJQUFjO0FBQ2hCO0FBQ0E7QUFDQSxPQUFPLGlCQUFpQjtBQUN4QixFQUFFLElBQWM7QUFDaEI7QUFDQTtBQUNBLE1BQU0sR0FBRyxDQUFDLGlCQUFpQjtBQUMzQixFQUFFLElBQWM7QUFDaEI7QUFDQTtBQUNBO0FBQ0EsT0FBTyxDQUFDLEdBQUc7QUFDWCxFQUFFLElBQWM7QUFDaEI7QUFDQSxFQUFFLHFCQUFxQjtBQUN2QixFQUFFLElBQWM7QUFDaEI7QUFDQSxFQUFFLHFCQUFxQjtBQUN2QixFQUFFLElBQWM7QUFDaEI7QUFDQSxHQUFHLG1CQUFtQjtBQUN0QixFQUFFLElBQWM7QUFDaEI7QUFDQSxFQUFFLEdBQUcsQ0FBQyxtQkFBbUI7QUFDekIsRUFBRSxJQUFjO0FBQ2hCO0FBQ0E7QUFDQTtBQUNBLE9BQU8sQ0FBQyxHQUFHO0FBQ1gsRUFBRSxJQUFjO0FBQ2hCO0FBQ0EsRUFBRSwyQkFBMkI7QUFDN0IsRUFBRSxJQUFjO0FBQ2hCO0FBQ0EsRUFBRSwyQkFBMkI7QUFDN0IsRUFBRSxJQUFjO0FBQ2hCO0FBQ0EsR0FBRyx5QkFBeUI7QUFDNUIsRUFBRSxJQUFjO0FBQ2hCO0FBQ0EsRUFBRSxHQUFHLENBQUMseUJBQXlCO0FBQy9CLEVBQUUsSUFBYztBQUNoQjtBQUNBO0FBQ0E7QUFDQSxPQUFPLENBQUMsR0FBRztBQUNYLEVBQUUsSUFBYztBQUNoQjtBQUNBO0FBQ0E7QUFDQSxFQUFFLHFDQUFxQztBQUN2QyxFQUFFLElBQWM7QUFDaEI7QUFDQTtBQUNBO0FBQ0EsRUFBRSxxQ0FBcUM7QUFDdkMsRUFBRSxJQUFjO0FBQ2hCO0FBQ0E7QUFDQTtBQUNBLEdBQUcsbUNBQW1DO0FBQ3RDLEVBQUUsSUFBYztBQUNoQjtBQUNBO0FBQ0E7QUFDQSxFQUFFLEdBQUcsQ0FBQyxtQ0FBbUM7QUFDekMsRUFBRSxJQUFjO0FBQ2hCO0FBQ0E7QUFDQTtBQUNBLE9BQU8sQ0FBQyxHQUFHO0FBQ1gsRUFBRSxJQUFjO0FBQ2hCO0FBQ0EsRUFBRSxpQkFBaUI7QUFDbkIsRUFBRSxpQkFBaUI7QUFDbkIsR0FBRyxlQUFlO0FBQ2xCLEVBQUUsR0FBRyxDQUFDLGVBQWU7QUFDckI7QUFDQSxFQUFFLElBQWM7QUFDaEI7QUFDQTtBQUNBO0FBQ0EsT0FBTyxDQUFDLEdBQUc7QUFDWCxFQUFFLElBQWM7QUFDaEI7QUFDQSxFQUFFLG9DQUFvQztBQUN0QyxFQUFFLG9DQUFvQztBQUN0QyxHQUFHLGtDQUFrQztBQUNyQyxFQUFFLEdBQUcsQ0FBQyxrQ0FBa0M7QUFDeEM7QUFDQSxFQUFFLElBQWM7QUFDaEI7QUFDQTtBQUNBO0FBQ0E7QUFDQSxPQUFPLENBQUMsR0FBRztBQUNYLEVBQUUsSUFBYztBQUNoQjtBQUNBLEVBQUUsSUFBYztBQUNoQjtBQUNBLEVBQUUsdUNBQXVDO0FBQ3pDLEVBQUUsdUNBQXVDO0FBQ3pDO0FBQ0EsR0FBRyxxQ0FBcUM7QUFDeEMsRUFBRSxHQUFHLENBQUMscUNBQXFDO0FBQzNDO0FBQ0EsRUFBRSxJQUFjO0FBQ2hCO0FBQ0E7QUFDQTtBQUNBO0FBQ0EsT0FBTyxDQUFDLEdBQUc7QUFDWCxFQUFFLElBQWM7QUFDaEI7QUFDQSxFQUFFLDJDQUEyQztBQUM3QyxFQUFFLDJDQUEyQztBQUM3QztBQUNBLEdBQUcseUNBQXlDO0FBQzVDLEVBQUUsR0FBRyxDQUFDLHlDQUF5QztBQUMvQyIsImlnbm9yZUxpc3QiOlsxXX0="
 `;
 
 exports[`the ESM version should transform code correctly > for excluded-strings 1`] = `

--- a/tests/unit/yarn.lock
+++ b/tests/unit/yarn.lock
@@ -92,7 +92,7 @@ __metadata:
 
 "@datadog/instrumentation-test-plugin@file:../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::locator=%40datadog%2Fjs-instrumentation-wasm-unit-tests%40workspace%3A.":
   version: 0.1
-  resolution: "@datadog/instrumentation-test-plugin@file:../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=c656dd&locator=%40datadog%2Fjs-instrumentation-wasm-unit-tests%40workspace%3A."
+  resolution: "@datadog/instrumentation-test-plugin@file:../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=27ecc2&locator=%40datadog%2Fjs-instrumentation-wasm-unit-tests%40workspace%3A."
   dependencies:
     unplugin: "npm:^2.3.4"
   peerDependencies:
@@ -118,7 +118,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/b05233d8cc629bf444e89f68cbb34ec48723a82924da6d2e326d022ce3cca032dec401a12f1b7ac7baa4ce56e43b6c3a4c309e7f8882e0950376eec37aadbd96
+  checksum: 10c0/0f6a6573bd898c3e1ba89b095881c3db01f60d260ce621dd93d326a244e9fc15abce64ff53b154b668dae4d092d1adfc0eecf8cad6419e9ed7aaacd05e0449e9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature / Major Change / Refactor / Optimization
- [ ] Bug Fix
- [ ] Documentation Update

## Description

This PR adds support for eslint-like directives that can be used to exclude strings from the allowlist. The supported directives are:
* `datadog-privacy-allowlist-exclude-file`: excludes the entire file it's found in.
* `datadog-privacy-allowlist-exclude-begin`: excludes any string from this point to the next `exclude-end`, or to the end of the file if no `exclude-end` is found.
* `datadog-privacy-allowlist-exclude-begin`: terminates `exclude-begin`.
* `datadog-privacy-allowlist-exclude-line`: excludes any string on the same line as the comment.
* `datadog-privacy-allowlist-exclude-next-line`: excludes any string on the line after the comment.

There are two main use cases for these directives:
1. They allow customers to exclude strings that should not be allowlisted for privacy reasons. (For example, many customers might want to do this for genders like `Male` or `Female`, which are usually sensitive data.)
2. They allow customers to exclude strings that should not be allowlisted because the transformations we apply for allowlisted strings break their code. This should be quite rare, but because JavaScript is so dynamic, there are cases where it's unavoidable -- in particular, code which inspects the result of `Function#toString()` will change its behavior as a result of our transformations, and customers may sometimes need the capability to opt out.

### Examples:

This will include `London`, `Amsterdam`, and 'Paris' in the allowlist, but exclude `Bristol`:
```js
const branch = [
  'London',
  'Bristol',  // datadog-privacy-allowlist-exclude-line
  'Amsterdam',
  'Paris',
];
```

This is another way of achieving the same thing:
```js
const branch = [
  'London',
  // datadog-privacy-allowlist-exclude-next-line
  'Bristol',
  'Amsterdam',
  'Paris',
];
```

This will include 'London' and 'Paris' in the allowlist, but exclude 'Bristol' and 'Amsterdam':
```js
const branch = [
  'London',
  // datadog-privacy-allowlist-exclude-begin
  'Bristol',
  'Amsterdam',
  // datadog-privacy-allowlist-exclude-end
  'Paris',
];
```