### PR TITLE
Make unused identifier tracking much more precise

### DIFF
--- a/rust/js-instrumentation-transform/src/identifiers/character_tracker.rs
+++ b/rust/js-instrumentation-transform/src/identifiers/character_tracker.rs
@@ -1,0 +1,208 @@
+use super::character_usage_data::CharacterUsageData;
+
+pub struct CharacterTracker {
+    // An array that maps valid JS identifier characters to usage data for
+    // each character. There are 64 characters to consider:
+    // * 26 uppercase letters
+    // * 26 lowercase letters
+    // * 10 digits
+    // * '$'
+    // * '_'
+    pub characters: [CharacterUsageData; 64],
+}
+
+impl CharacterTracker {
+    pub fn new() -> CharacterTracker {
+        let mut set = CharacterTracker {
+            characters: [CharacterUsageData::DEFAULT; 64],
+        };
+
+        // A JS identifier can't begin with a digit. To ensure that we don't generate invalid
+        // identifiers, we pretend that we've seen every digit at index 0.
+        for digit in '0'..='9' {
+            set.add(&digit.to_string());
+        }
+
+        // Some internationalization libraries require you to wrap string literals in a function
+        // called "_()" or "__()". To minimize the risk of any confusion, ensure that we never
+        // generate an identifier that would collide with this function.
+        set.add("_");
+        set.add("__");
+
+        set
+    }
+
+    pub fn add(self: &mut Self, string: &str) {
+        match string.chars().enumerate().last() {
+            Some((position, character)) => match Self::index_for(character) {
+                Some(index) => {
+                    self.characters[index].add_usage(position);
+                }
+                None => {}
+            },
+            None => {}
+        }
+    }
+
+    pub fn first_unused_character(self: &Self) -> (char, usize) {
+        self.characters
+            .iter()
+            .enumerate()
+            .min_by(|(_, a_position), (_, b_position)| {
+                a_position.first_unused().cmp(&b_position.first_unused())
+            })
+            .map(|(index, position)| (Self::character_for(index).unwrap(), position.first_unused()))
+            .unwrap()
+    }
+
+    fn character_for(index: usize) -> Option<char> {
+        match index {
+            // Uppercase letters: indices 0 to 25.
+            0..=25 => Some(('A' as u8 + index as u8) as char),
+            // Lowercase letters: indices 26 to 51.
+            26..=51 => Some(('a' as u8 + index as u8 - 26) as char),
+            // Digits: indices 52 to 61.
+            52..=61 => Some(('0' as u8 + index as u8 - 52) as char),
+            // '$': index 62.
+            62 => Some('$'),
+            // '_': index 63.
+            63 => Some('_'),
+            // Ignore other characters.
+            _ => None,
+        }
+    }
+
+    fn index_for(character: char) -> Option<usize> {
+        match character {
+            // Uppercase letters: indices 0 to 25.
+            'A'..='Z' => Some((character as u32 - 'A' as u32) as usize),
+            // Lowercase letters: indices 26 to 51.
+            'a'..='z' => Some((character as u32 - 'a' as u32) as usize + 26),
+            // Digits: indices 52 to 61.
+            '0'..='9' => Some((character as u32 - '0' as u32) as usize + 52),
+            // '$': index 62.
+            '$' => Some(62),
+            // '_': index 63.
+            '_' => Some(63),
+            // Ignore other characters.
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::iter::once;
+
+    use super::*;
+
+    #[test]
+    fn uses_consistent_indices_for_characters() {
+        for nondigit in ('A'..='Z').chain('a'..='z').chain(once('$')) {
+            assert_character_has_consistent_index(nondigit, 0);
+        }
+        for digit in '0'..='9' {
+            assert_character_has_consistent_index(digit, 1);
+        }
+        assert_character_has_consistent_index('_', 2);
+    }
+
+    fn assert_character_has_consistent_index(character: char, expected_first_unused_pos: usize) {
+        // Check that an index exists for this character.
+        let index = CharacterTracker::index_for(character);
+        assert!(index.is_some());
+        let index = index.unwrap();
+
+        // Check that mapping we can map the index back to the original character.
+        assert_eq!(CharacterTracker::character_for(index), Some(character));
+
+        // Check that the first unused position for this character is what we expect.
+        let mut character_tracker = CharacterTracker::new();
+        assert_eq!(
+            character_tracker.characters[index].first_unused(),
+            expected_first_unused_pos
+        );
+
+        // Check that adding an instance of this character changes the first unused position.
+        character_tracker.add(&character.to_string().repeat(expected_first_unused_pos + 1));
+        assert_eq!(
+            character_tracker.characters[index].first_unused(),
+            expected_first_unused_pos + 1
+        );
+    }
+
+    #[test]
+    fn finds_an_unused_character() {
+        let mut character_tracker = CharacterTracker::new();
+
+        // Add all single character identifiers except 'z'.
+        for_every_identifier_character(|character| {
+            if character == 'z' {
+                return;
+            }
+            character_tracker.add(&character.to_string());
+        });
+
+        assert_eq!(character_tracker.first_unused_character(), ('z', 0));
+    }
+
+    #[test]
+    fn finds_an_unused_character_when_all_single_character_identifiers_are_used() {
+        let mut character_tracker = CharacterTracker::new();
+
+        // Add all single character identifiers.
+        for_every_identifier_character(|character| {
+            character_tracker.add(&character.to_string());
+        });
+
+        assert_eq!(character_tracker.first_unused_character(), ('A', 1));
+    }
+
+    #[test]
+    fn finds_an_unused_character_when_all_characters_at_pos_1_are_used() {
+        let mut character_tracker = CharacterTracker::new();
+
+        // Add an example of every character at position 1: e.g. "Aa", "Ab",
+        // "Ac", etc. We should still be able to find an available character
+        // at position 0.
+        for_every_identifier_character(|character| {
+            character_tracker.add(&format!("A{}", character.to_string()));
+        });
+
+        assert_eq!(character_tracker.first_unused_character(), ('A', 0));
+    }
+
+    #[test]
+    fn finds_an_unused_character_when_all_characters_at_pos_0_and_1_are_used() {
+        let mut character_tracker = CharacterTracker::new();
+
+        // Add an example of every character at position 0: e.g. "A", "B",
+        // "C", etc.
+        for_every_identifier_character(|character| {
+            character_tracker.add(&character.to_string());
+        });
+
+        // Add an example of every character at position 1: e.g. "Aa", "Ab",
+        // "Ac", etc.
+        for_every_identifier_character(|character| {
+            character_tracker.add(&format!("A{}", character.to_string()));
+        });
+
+        // We should consider the first unused character to be at position 2.
+        assert_eq!(character_tracker.first_unused_character(), ('A', 2));
+    }
+
+    fn for_every_identifier_character<F>(mut f: F)
+    where
+        F: FnMut(char) -> (),
+    {
+        for character in ('A'..='Z')
+            .chain('a'..='z')
+            .chain('0'..='9')
+            .chain(once('$'))
+            .chain(once('_'))
+        {
+            f(character);
+        }
+    }
+}

--- a/rust/js-instrumentation-transform/src/identifiers/character_usage_data.rs
+++ b/rust/js-instrumentation-transform/src/identifiers/character_usage_data.rs
@@ -1,0 +1,59 @@
+use std::cmp::max;
+
+/// Metadata about where a character has been used in identifiers
+/// we've encountered in the input so far.
+#[derive(Debug)]
+pub struct CharacterUsageData {
+    /// This bit mask tracks whether the character has appeared in
+    /// the first 16 positions within any identifier. If a bit is
+    /// set to 1, it means that the character has appeared in that
+    /// position. For example, for the character 'x', if we've seen
+    /// the identifiers 'x' and 'box', 'low_pos_mask' will be:
+    ///   0b0000000000000101
+    pub low_pos_mask: u16,
+
+    /// This number tracks the lowest position greater than every
+    /// position at which we've seen the character. For example,
+    /// for the 'x' and 'box' example above, 'upper_bound' will be
+    /// 3, because the highest position we've seen for the character
+    /// 'x' is at index 2 in 'box'.
+    pub upper_bound: u16,
+}
+
+impl CharacterUsageData {
+    pub const DEFAULT: CharacterUsageData = CharacterUsageData {
+        low_pos_mask: 0,
+        upper_bound: 0,
+    };
+
+    pub fn add_usage(self: &mut Self, position: usize) {
+        let pos_16: u16 = position.try_into().unwrap_or(u16::MAX);
+        if pos_16 < 16 {
+            self.low_pos_mask = self.low_pos_mask | (1 << pos_16);
+        }
+
+        if pos_16 == u16::MAX {
+            self.upper_bound = u16::MAX
+        } else {
+            self.upper_bound = max(self.upper_bound, pos_16 + 1);
+        }
+    }
+
+    pub fn first_unused(self: &Self) -> usize {
+        if self.low_pos_mask < u16::MAX {
+            for position in 0..16 {
+                if self.low_pos_mask & (1 << position) == 0 {
+                    return position;
+                }
+            }
+        }
+
+        self.upper_bound as usize
+    }
+}
+
+impl Default for CharacterUsageData {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}

--- a/rust/js-instrumentation-transform/src/identifiers/identifier_tracker.rs
+++ b/rust/js-instrumentation-transform/src/identifiers/identifier_tracker.rs
@@ -1,6 +1,8 @@
-use std::{cmp::max, collections::HashMap};
+use std::collections::HashMap;
 
 use swc_ecma_ast::{Ident, IdentName};
+
+use super::character_tracker::CharacterTracker;
 
 pub struct IdentifierTracker {
     desired_identifier_availability: HashMap<String, bool>,
@@ -43,9 +45,9 @@ impl IdentifierTracker {
             _ => {}
         };
 
-        // Generate a new, unused identifier. We do this by selecting a character which is known to
-        // be unused in any identifier at a certain string position, and then generating an
-        // identifier which places the character at this position.
+        // Generate a new, unused identifier. We do this by selecting a character which is
+        // known not to appear at the end of any identifier of a certain length, and then
+        // generating an identifier with that length which ends in the selected character.
         let (unused_char, position) = self.tracker.first_unused_character();
         let unused_identifier = format!("{}{}", "D".repeat(position), unused_char);
 
@@ -63,92 +65,6 @@ impl IdentifierTracker {
                     .insert(string.into(), false);
             }
             _ => {}
-        }
-    }
-}
-
-struct CharacterTracker {
-    // An array that maps valid JS identifier characters to the first position at which we've never
-    // seen them occur. There are 64 characters to consider:
-    // * 26 uppercase letters
-    // * 26 lowercase letters
-    // * 10 digits
-    // * '$'
-    // * '_'
-    pub characters: [usize; 64],
-}
-
-impl CharacterTracker {
-    pub fn new() -> CharacterTracker {
-        let mut set = CharacterTracker {
-            characters: [0; 64],
-        };
-
-        // A JS identifier can't begin with a digit. To ensure that we don't generate invalid
-        // identifiers, we pretend that we've seen every digit at index 0.
-        for digit in '0'..='9' {
-            set.add(&digit.to_string());
-        }
-
-        // Some internationalization libraries require you to wrap string literals in a function
-        // called "__()". To minimize the risk of any confusion, ensure that we never generate an
-        // identifier that would collide with this function.
-        set.add("__");
-
-        set
-    }
-
-    pub fn add(self: &mut Self, string: &str) {
-        for (position, character) in string.chars().enumerate() {
-            match Self::index_for(character) {
-                Some(index) => {
-                    self.characters[index] = max(self.characters[index], position + 1);
-                }
-                None => {}
-            }
-        }
-    }
-
-    pub fn first_unused_character(self: &Self) -> (char, usize) {
-        self.characters
-            .iter()
-            .enumerate()
-            .min_by(|(_, a_position), (_, b_position)| a_position.cmp(b_position))
-            .map(|(index, position)| (Self::character_for(index).unwrap(), position.clone()))
-            .unwrap()
-    }
-
-    fn character_for(index: usize) -> Option<char> {
-        match index {
-            // Uppercase letters: indices 0 to 25.
-            0..=25 => Some(('A' as u8 + index as u8) as char),
-            // Lowercase letters: indices 26 to 51.
-            26..=51 => Some(('a' as u8 + index as u8) as char),
-            // Digits: indices 52 to 61.
-            52..=61 => Some(('0' as u8 + index as u8) as char),
-            // '$': index 62.
-            62 => Some('$'),
-            // '_': index 63.
-            63 => Some('_'),
-            // Ignore other characters.
-            _ => None,
-        }
-    }
-
-    fn index_for(character: char) -> Option<usize> {
-        match character {
-            // Uppercase letters: indices 0 to 25.
-            'A'..='Z' => Some((character as u32 - 'A' as u32) as usize),
-            // Lowercase letters: indices 26 to 51.
-            'a'..='z' => Some((character as u32 - 'a' as u32) as usize + 26),
-            // Digits: indices 52 to 61.
-            '0'..='9' => Some((character as u32 - '0' as u32) as usize + 52),
-            // '$': index 62.
-            '$' => Some(62),
-            // '_': index 63.
-            '_' => Some(63),
-            // Ignore other characters.
-            _ => None,
         }
     }
 }

--- a/rust/js-instrumentation-transform/src/identifiers/mod.rs
+++ b/rust/js-instrumentation-transform/src/identifiers/mod.rs
@@ -1,2 +1,6 @@
+mod character_usage_data;
+
+mod character_tracker;
+
 mod identifier_tracker;
 pub use identifier_tracker::IdentifierTracker;

--- a/tests/instrumentation-test-plugin/yarn.lock
+++ b/tests/instrumentation-test-plugin/yarn.lock
@@ -150,8 +150,8 @@ __metadata:
 
 "@datadog/js-instrumentation-wasm@file:../../artifacts/@datadog-js-instrumentation-wasm.tgz::locator=%40datadog%2Finstrumentation-test-plugin%40workspace%3A.":
   version: 1.0.0
-  resolution: "@datadog/js-instrumentation-wasm@file:../../artifacts/@datadog-js-instrumentation-wasm.tgz#../../artifacts/@datadog-js-instrumentation-wasm.tgz::hash=2a937b&locator=%40datadog%2Finstrumentation-test-plugin%40workspace%3A."
-  checksum: 10c0/ed228333e6693d6d4d053ac634198ae172490f42190ae034cd6726728fbb5b75111ef13b8b2baf52e75de679311fa95e0950869c6771f9cd7f1e43816bce076f
+  resolution: "@datadog/js-instrumentation-wasm@file:../../artifacts/@datadog-js-instrumentation-wasm.tgz#../../artifacts/@datadog-js-instrumentation-wasm.tgz::hash=ce70d4&locator=%40datadog%2Finstrumentation-test-plugin%40workspace%3A."
+  checksum: 10c0/7d1f3dceaff10cc92290fd75889c3a776b8a58d47d8f471bdf7d41d3c9661f6b9b44778d6536197a0d0038181c0e9ccbd0aba8b7488807267fecd98c80c2c97e
   languageName: node
   linkType: hard
 

--- a/tests/integration/esbuild/yarn.lock
+++ b/tests/integration/esbuild/yarn.lock
@@ -93,7 +93,7 @@ __metadata:
 
 "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::locator=esbuild-project%40workspace%3A.":
   version: 0.1
-  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=b10768&locator=esbuild-project%40workspace%3A."
+  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=b31f8c&locator=esbuild-project%40workspace%3A."
   dependencies:
     unplugin: "npm:^2.3.4"
   peerDependencies:
@@ -119,7 +119,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/5fd5c2795b7d8a907e1f19b8141abb1e888dc8d6e695b08ba099b4c9a0af6805cc07833fb590ac286c321db17666afce1311a70610845e09135dc60b66ac97e1
+  checksum: 10c0/7be9008bf9407471b71ae71d6efd3abf078d92b74b6977789a6d3d83caf685d7f84ee25e7f54fc81249c2e7d193e9855f64805c65915833fb4cd98201a45df48
   languageName: node
   linkType: hard
 

--- a/tests/integration/vite-with-yarn-pnp/yarn.lock
+++ b/tests/integration/vite-with-yarn-pnp/yarn.lock
@@ -282,7 +282,7 @@ __metadata:
 
 "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::locator=vite-project%40workspace%3A.":
   version: 0.1
-  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=b10768&locator=vite-project%40workspace%3A."
+  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=b31f8c&locator=vite-project%40workspace%3A."
   dependencies:
     unplugin: "npm:^2.3.4"
   peerDependencies:
@@ -308,7 +308,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/5fd5c2795b7d8a907e1f19b8141abb1e888dc8d6e695b08ba099b4c9a0af6805cc07833fb590ac286c321db17666afce1311a70610845e09135dc60b66ac97e1
+  checksum: 10c0/7be9008bf9407471b71ae71d6efd3abf078d92b74b6977789a6d3d83caf685d7f84ee25e7f54fc81249c2e7d193e9855f64805c65915833fb4cd98201a45df48
   languageName: node
   linkType: hard
 

--- a/tests/integration/vite/yarn.lock
+++ b/tests/integration/vite/yarn.lock
@@ -282,7 +282,7 @@ __metadata:
 
 "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::locator=vite-project%40workspace%3A.":
   version: 0.1
-  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=b10768&locator=vite-project%40workspace%3A."
+  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=b31f8c&locator=vite-project%40workspace%3A."
   dependencies:
     unplugin: "npm:^2.3.4"
   peerDependencies:
@@ -308,7 +308,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/5fd5c2795b7d8a907e1f19b8141abb1e888dc8d6e695b08ba099b4c9a0af6805cc07833fb590ac286c321db17666afce1311a70610845e09135dc60b66ac97e1
+  checksum: 10c0/7be9008bf9407471b71ae71d6efd3abf078d92b74b6977789a6d3d83caf685d7f84ee25e7f54fc81249c2e7d193e9855f64805c65915833fb4cd98201a45df48
   languageName: node
   linkType: hard
 

--- a/tests/integration/webpack/yarn.lock
+++ b/tests/integration/webpack/yarn.lock
@@ -93,7 +93,7 @@ __metadata:
 
 "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::locator=webpack-react-typescript-example%40workspace%3A.":
   version: 0.1
-  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=b10768&locator=webpack-react-typescript-example%40workspace%3A."
+  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=b31f8c&locator=webpack-react-typescript-example%40workspace%3A."
   dependencies:
     unplugin: "npm:^2.3.4"
   peerDependencies:
@@ -119,7 +119,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/5fd5c2795b7d8a907e1f19b8141abb1e888dc8d6e695b08ba099b4c9a0af6805cc07833fb590ac286c321db17666afce1311a70610845e09135dc60b66ac97e1
+  checksum: 10c0/7be9008bf9407471b71ae71d6efd3abf078d92b74b6977789a6d3d83caf685d7f84ee25e7f54fc81249c2e7d193e9855f64805c65915833fb4cd98201a45df48
   languageName: node
   linkType: hard
 

--- a/tests/unit/yarn.lock
+++ b/tests/unit/yarn.lock
@@ -92,7 +92,7 @@ __metadata:
 
 "@datadog/instrumentation-test-plugin@file:../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::locator=%40datadog%2Fjs-instrumentation-wasm-unit-tests%40workspace%3A.":
   version: 0.1
-  resolution: "@datadog/instrumentation-test-plugin@file:../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=b10768&locator=%40datadog%2Fjs-instrumentation-wasm-unit-tests%40workspace%3A."
+  resolution: "@datadog/instrumentation-test-plugin@file:../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=b31f8c&locator=%40datadog%2Fjs-instrumentation-wasm-unit-tests%40workspace%3A."
   dependencies:
     unplugin: "npm:^2.3.4"
   peerDependencies:
@@ -118,7 +118,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/5fd5c2795b7d8a907e1f19b8141abb1e888dc8d6e695b08ba099b4c9a0af6805cc07833fb590ac286c321db17666afce1311a70610845e09135dc60b66ac97e1
+  checksum: 10c0/7be9008bf9407471b71ae71d6efd3abf078d92b74b6977789a6d3d83caf685d7f84ee25e7f54fc81249c2e7d193e9855f64805c65915833fb4cd98201a45df48
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature / Major Change / Refactor / Optimization
- [x] Bug Fix
- [ ] Documentation Update

## Description

During the instrumentation process, `js-instrumentation-wasm` tracks the identifiers that it has seen so that it can generate new identifiers for the symbols it injects (like the helper function and the dictionary) that won't conflict with anything that already exists. It does this by keeping track of the positions at which each possible identifier character has appeared, so that it can generate new identifiers that differ from existing identifiers by at least one character. This work happens in `IdentifierTracker` and its helper type `CharacterTracker`.

We recently noticed a bug in this code: when there are a large number of identifiers, `IdentifierTracker`  sometimes reuses identifier names it has already used: it gives the same name to the helper function identifier and the dictionary identifier. I tracked this down to an inconsistency in the way we convert the characters we're tracking into numbers; for some characters, we used a different number to look them up in the character table than we used when updating the character table, creating the discrepancy.

I refactored the code in order to fix this. As part of the refactor, I changed the way we represent the position metadata we track for each character. Before, we only tracked the highest position at which we had seen each character. This means that if we saw the identifier `box`, all we knew about `x` was that we had seen it at character position 3 (and maybe other character positions lower than that!), so we could never place an `x` anywhere before the fourth character in an identifier name. Obviously this meant that we were sometimes generating unnecessarily long identifiers!

After this PR, we will track information about the first 16 character positions independently. This means that if we see `box`, we will consider `x` to be unavailable in position 3, but we can still generate identifiers with an `x` as their first or second character.

Going further, we also now only track position metadata for the _last_ character in each identifier we see, and we only focus on making sure that the last character is unique when generating identifiers. Because generated identifiers only need to differ from existing identifiers by one character, focusing on the last character is enough to accomplish our goal. This change, again, should free up more identifiers. With the old approach, if we saw the identifier `box`, we would never be allowed to generate an identifier named `b`, because the fact that `box` starts with `b` made `b` unavailable at the first character position. With the new approach, we only care about the last character in `box`, so seeing `box` only has the effect of making `x` unavailable to end identifiers which are three characters long; we can still generate the identifier `b`.

So, after this PR lands, the `IdentifierTracker` code should be both more reliable and much better at finding unused short identifiers. To validate all of these changes, I've also added a new suite of Rust unit tests that thoroughly tests this code. These tests check for the kinds of issues that led to the bug we discovered in `IdentifierTracker`; I'm much more confident in the code now that they're in place.