### PR TITLE
Detect export-only CJS modules

### DIFF
--- a/rust/js-instrumentation-shared/src/module_kind.rs
+++ b/rust/js-instrumentation-shared/src/module_kind.rs
@@ -13,8 +13,8 @@ pub enum ModuleKind {
 }
 
 pub struct ModuleKeywordUsage {
-    pub es_modules: bool,
-    pub require: bool,
+    pub cjs: bool,
+    pub esm: bool,
 }
 
 pub fn module_kind_for(
@@ -31,19 +31,14 @@ pub fn module_kind_for(
         _ if filename_is_explicitly_esm(filename) => ModuleKind::ESM,
 
         // If the file contained `import` or `export`, treat it as ESM.
-        (
-            None,
-            Some(ModuleKeywordUsage {
-                es_modules: true, ..
-            }),
-        ) => ModuleKind::ESM,
+        (None, Some(ModuleKeywordUsage { esm: true, .. })) => ModuleKind::ESM,
 
-        // If it contained `require()`, but no `import` or `export`, treat it as CJS.
+        // If it contained `require()` or `exports`, but no `import` or `export`, treat it as CJS.
         (
             None,
             Some(ModuleKeywordUsage {
-                es_modules: false,
-                require: true,
+                esm: false,
+                cjs: true,
             }),
         ) => ModuleKind::CJS,
 

--- a/rust/js-instrumentation-transform/src/features/feature_tracker.rs
+++ b/rust/js-instrumentation-transform/src/features/feature_tracker.rs
@@ -8,17 +8,17 @@ impl FeatureTracker {
     pub fn new() -> FeatureTracker {
         FeatureTracker {
             module_keyword_usage: ModuleKeywordUsage {
-                es_modules: false,
-                require: false,
+                cjs: false,
+                esm: false,
             },
         }
     }
 
-    pub fn observed_require(self: &mut Self) {
-        self.module_keyword_usage.require = true;
+    pub fn observed_cjs_exports_or_require(self: &mut Self) {
+        self.module_keyword_usage.cjs = true;
     }
 
-    pub fn observed_export_or_import(self: &mut Self) {
-        self.module_keyword_usage.es_modules = true;
+    pub fn observed_esm_export_or_import(self: &mut Self) {
+        self.module_keyword_usage.esm = true;
     }
 }

--- a/tests/fixtures/commonjs-exports/input.js
+++ b/tests/fixtures/commonjs-exports/input.js
@@ -1,0 +1,4 @@
+exports.foo = 'hello';
+exports.bar = function() {
+  return true;
+};

--- a/tests/fixtures/commonjs-exports/output.js
+++ b/tests/fixtures/commonjs-exports/output.js
@@ -1,0 +1,4 @@
+const{$}=require('datadog:privacy-helpers.cjs');const D=$(['hello']);exports.foo = D[0];
+exports.bar = function() {
+  return true;
+};

--- a/tests/fixtures/commonjs-module-exports/input.js
+++ b/tests/fixtures/commonjs-module-exports/input.js
@@ -1,0 +1,6 @@
+module.exports = {
+  foo: 'hello',
+  bar() {
+    return true;
+  }
+};

--- a/tests/fixtures/commonjs-module-exports/output.js
+++ b/tests/fixtures/commonjs-module-exports/output.js
@@ -1,0 +1,6 @@
+const{$}=require('datadog:privacy-helpers.cjs');const D=$(['hello']);module.exports = {
+  foo: D[0],
+  bar() {
+    return true;
+  }
+};

--- a/tests/instrumentation-test-plugin/yarn.lock
+++ b/tests/instrumentation-test-plugin/yarn.lock
@@ -150,8 +150,8 @@ __metadata:
 
 "@datadog/js-instrumentation-wasm@file:../../artifacts/@datadog-js-instrumentation-wasm.tgz::locator=%40datadog%2Finstrumentation-test-plugin%40workspace%3A.":
   version: 1.0.1
-  resolution: "@datadog/js-instrumentation-wasm@file:../../artifacts/@datadog-js-instrumentation-wasm.tgz#../../artifacts/@datadog-js-instrumentation-wasm.tgz::hash=639fa3&locator=%40datadog%2Finstrumentation-test-plugin%40workspace%3A."
-  checksum: 10c0/531a1b4ec5821d013ee7b42bb060e59ef436a13ddadeb44c9a61c80f3a247c0501fbd6f61c3b72ace446aeb04bfdccbeab170fcb0bf933de38ef513fde667f0e
+  resolution: "@datadog/js-instrumentation-wasm@file:../../artifacts/@datadog-js-instrumentation-wasm.tgz#../../artifacts/@datadog-js-instrumentation-wasm.tgz::hash=26c0e0&locator=%40datadog%2Finstrumentation-test-plugin%40workspace%3A."
+  checksum: 10c0/20a7b0bdc1b5a7d3b927257a8699a3277137b9f42bd5d9d9bf93f5f0f5084a58b472944626c9b63fa49d929e6e1b540b305cec7fae2007f09a96acae2527fc59
   languageName: node
   linkType: hard
 

--- a/tests/integration/esbuild/yarn.lock
+++ b/tests/integration/esbuild/yarn.lock
@@ -93,7 +93,7 @@ __metadata:
 
 "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::locator=esbuild-project%40workspace%3A.":
   version: 0.1
-  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=4887fd&locator=esbuild-project%40workspace%3A."
+  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=3a2be8&locator=esbuild-project%40workspace%3A."
   dependencies:
     unplugin: "npm:^2.3.4"
   peerDependencies:
@@ -119,7 +119,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/a13a348559e205a5c496e5f42f45844a5a9973512bf5ce6449e3d1c87c7411026133f2059797711c8c337a711029a51dd17de7cb791307a93ba5b25dff467c84
+  checksum: 10c0/4f0589a75c591117f74463370d2c7d27705c570677ee571e82f23e747b9495f74f662b93ff860e0725f5a94541b9a23e1985c81406e42ec9ed2a75985224766a
   languageName: node
   linkType: hard
 

--- a/tests/integration/vite-with-yarn-pnp/yarn.lock
+++ b/tests/integration/vite-with-yarn-pnp/yarn.lock
@@ -282,7 +282,7 @@ __metadata:
 
 "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::locator=vite-project%40workspace%3A.":
   version: 0.1
-  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=4887fd&locator=vite-project%40workspace%3A."
+  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=3a2be8&locator=vite-project%40workspace%3A."
   dependencies:
     unplugin: "npm:^2.3.4"
   peerDependencies:
@@ -308,7 +308,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/a13a348559e205a5c496e5f42f45844a5a9973512bf5ce6449e3d1c87c7411026133f2059797711c8c337a711029a51dd17de7cb791307a93ba5b25dff467c84
+  checksum: 10c0/4f0589a75c591117f74463370d2c7d27705c570677ee571e82f23e747b9495f74f662b93ff860e0725f5a94541b9a23e1985c81406e42ec9ed2a75985224766a
   languageName: node
   linkType: hard
 

--- a/tests/integration/vite/yarn.lock
+++ b/tests/integration/vite/yarn.lock
@@ -282,7 +282,7 @@ __metadata:
 
 "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::locator=vite-project%40workspace%3A.":
   version: 0.1
-  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=4887fd&locator=vite-project%40workspace%3A."
+  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=3a2be8&locator=vite-project%40workspace%3A."
   dependencies:
     unplugin: "npm:^2.3.4"
   peerDependencies:
@@ -308,7 +308,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/a13a348559e205a5c496e5f42f45844a5a9973512bf5ce6449e3d1c87c7411026133f2059797711c8c337a711029a51dd17de7cb791307a93ba5b25dff467c84
+  checksum: 10c0/4f0589a75c591117f74463370d2c7d27705c570677ee571e82f23e747b9495f74f662b93ff860e0725f5a94541b9a23e1985c81406e42ec9ed2a75985224766a
   languageName: node
   linkType: hard
 

--- a/tests/integration/webpack/yarn.lock
+++ b/tests/integration/webpack/yarn.lock
@@ -93,7 +93,7 @@ __metadata:
 
 "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::locator=webpack-react-typescript-example%40workspace%3A.":
   version: 0.1
-  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=4887fd&locator=webpack-react-typescript-example%40workspace%3A."
+  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=3a2be8&locator=webpack-react-typescript-example%40workspace%3A."
   dependencies:
     unplugin: "npm:^2.3.4"
   peerDependencies:
@@ -119,7 +119,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/a13a348559e205a5c496e5f42f45844a5a9973512bf5ce6449e3d1c87c7411026133f2059797711c8c337a711029a51dd17de7cb791307a93ba5b25dff467c84
+  checksum: 10c0/4f0589a75c591117f74463370d2c7d27705c570677ee571e82f23e747b9495f74f662b93ff860e0725f5a94541b9a23e1985c81406e42ec9ed2a75985224766a
   languageName: node
   linkType: hard
 

--- a/tests/unit/__snapshots__/index.test.ts.snap
+++ b/tests/unit/__snapshots__/index.test.ts.snap
@@ -17,6 +17,24 @@ foo({
 //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIiwiIl0sInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGZvbyB9IGZyb20gXCJteS1tb2R1bGUuanNcIjtcblxuLy8gY29uc3QgY29uc3RhbnQgPSBcInNvbWUgc3RyaW5nXCI7XG5jb25zdCBjb25zdGFudCA9IFwic29tZSBzdHJpbmdcIjtcblxuZm9vKHtcbiAgLy8gYmFyOiBcImFiY1wiLFxuICBiYXI6IFwiYWJjXCIsXG4gIC8vIGJhejogYHNvbWV0aGluZyR7Y29uc3RhbnR9NDU2YCxcbiAgYmF6OiBgc29tZXRoaW5nJHtjb25zdGFudH00NTZgLFxuICAvLyBiYXQ6IGZvb2AxMjMke2NvbnN0YW50fWFub3RoZXIgdGhpbmdgLFxuICBiYXQ6IGZvb2AxMjMke2NvbnN0YW50fWFub3RoZXIgdGhpbmdgLFxufSk7XG4iLCIiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6Im1HQUFBLFNBQVMsR0FBRyxRQUFRLGNBQWM7QUFDbEM7QUFDQTtBQUNBLE1BQU0sUUFBUSxHQUFHLElBQWE7QUFDOUI7QUFDQSxHQUFHLENBQUM7QUFDSjtBQUNBLEVBQUUsR0FBRyxFQUFFLElBQUs7QUFDWjtBQUNBLEVBQUUsR0FBRyxHQUFHLE9BQVMsRUFBRSxRQUFRLENBQUMsR0FBRztBQUMvQjtBQUNBLEVBQUUsR0FBRyxFQUFFLEdBQUcsS0FBQyxBQUFHLEVBQUUsUUFBUSxBQUFDLEFBQWE7QUFDdEMiLCJpZ25vcmVMaXN0IjpbMV19"
 `;
 
+exports[`should be able to set a custom expression addToDictionary helper > for commonjs-exports 1`] = `
+"const $=(v) => console.log(v);const D=$(['hello']);exports.foo = D[0];
+exports.bar = function() {
+  return true;
+};
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIiwiIl0sInNvdXJjZXNDb250ZW50IjpbImV4cG9ydHMuZm9vID0gJ2hlbGxvJztcbmV4cG9ydHMuYmFyID0gZnVuY3Rpb24oKSB7XG4gIHJldHVybiB0cnVlO1xufTtcbiIsIiJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoibURBQUEsT0FBTyxDQUFDLEdBQUcsR0FBRyxJQUFPO0FBQ3JCLE9BQU8sQ0FBQyxHQUFHLEdBQUcsV0FBVztBQUN6QixFQUFFLE9BQU87QUFDVCIsImlnbm9yZUxpc3QiOlsxXX0="
+`;
+
+exports[`should be able to set a custom expression addToDictionary helper > for commonjs-module-exports 1`] = `
+"const $=(v) => console.log(v);const D=$(['hello']);module.exports = {
+  foo: D[0],
+  bar() {
+    return true;
+  }
+};
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIiwiIl0sInNvdXJjZXNDb250ZW50IjpbIm1vZHVsZS5leHBvcnRzID0ge1xuICBmb286ICdoZWxsbycsXG4gIGJhcigpIHtcbiAgICByZXR1cm4gdHJ1ZTtcbiAgfVxufTtcbiIsIiJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoibURBQUEsTUFBTSxDQUFDLE9BQU8sR0FBRztBQUNqQixFQUFFLEdBQUcsRUFBRSxJQUFPO0FBQ2QsRUFBRSxHQUFHLEdBQUc7QUFDUixJQUFJLE9BQU87QUFDWDtBQUNBIiwiaWdub3JlTGlzdCI6WzFdfQ=="
+`;
+
 exports[`should be able to set a custom expression addToDictionary helper > for commonjs-require 1`] = `
 "const $=(v) => console.log(v);const D=$(['test']);const foo = require('foo-module');
 foo(D[0]);
@@ -689,6 +707,24 @@ foo({
   bat: foo(D[3], constant),
 });
 //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIiwiIl0sInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGZvbyB9IGZyb20gXCJteS1tb2R1bGUuanNcIjtcblxuLy8gY29uc3QgY29uc3RhbnQgPSBcInNvbWUgc3RyaW5nXCI7XG5jb25zdCBjb25zdGFudCA9IFwic29tZSBzdHJpbmdcIjtcblxuZm9vKHtcbiAgLy8gYmFyOiBcImFiY1wiLFxuICBiYXI6IFwiYWJjXCIsXG4gIC8vIGJhejogYHNvbWV0aGluZyR7Y29uc3RhbnR9NDU2YCxcbiAgYmF6OiBgc29tZXRoaW5nJHtjb25zdGFudH00NTZgLFxuICAvLyBiYXQ6IGZvb2AxMjMke2NvbnN0YW50fWFub3RoZXIgdGhpbmdgLFxuICBiYXQ6IGZvb2AxMjMke2NvbnN0YW50fWFub3RoZXIgdGhpbmdgLFxufSk7XG4iLCIiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IjJIQUFBLFNBQVMsR0FBRyxRQUFRLGNBQWM7QUFDbEM7QUFDQTtBQUNBLE1BQU0sUUFBUSxHQUFHLElBQWE7QUFDOUI7QUFDQSxHQUFHLENBQUM7QUFDSjtBQUNBLEVBQUUsR0FBRyxFQUFFLElBQUs7QUFDWjtBQUNBLEVBQUUsR0FBRyxHQUFHLE9BQVMsRUFBRSxRQUFRLENBQUMsR0FBRztBQUMvQjtBQUNBLEVBQUUsR0FBRyxFQUFFLEdBQUcsS0FBQyxBQUFHLEVBQUUsUUFBUSxBQUFDLEFBQWE7QUFDdEMiLCJpZ25vcmVMaXN0IjpbMV19"
+`;
+
+exports[`should be able to set a custom imported addToDictionary helper > for commonjs-exports 1`] = `
+"const{addToDictionary:$}=require('@custom/helpers.cjs');const D=$(['hello']);exports.foo = D[0];
+exports.bar = function() {
+  return true;
+};
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIiwiIl0sInNvdXJjZXNDb250ZW50IjpbImV4cG9ydHMuZm9vID0gJ2hlbGxvJztcbmV4cG9ydHMuYmFyID0gZnVuY3Rpb24oKSB7XG4gIHJldHVybiB0cnVlO1xufTtcbiIsIiJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiNkVBQUEsT0FBTyxDQUFDLEdBQUcsR0FBRyxJQUFPO0FBQ3JCLE9BQU8sQ0FBQyxHQUFHLEdBQUcsV0FBVztBQUN6QixFQUFFLE9BQU87QUFDVCIsImlnbm9yZUxpc3QiOlsxXX0="
+`;
+
+exports[`should be able to set a custom imported addToDictionary helper > for commonjs-module-exports 1`] = `
+"const{addToDictionary:$}=require('@custom/helpers.cjs');const D=$(['hello']);module.exports = {
+  foo: D[0],
+  bar() {
+    return true;
+  }
+};
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIiwiIl0sInNvdXJjZXNDb250ZW50IjpbIm1vZHVsZS5leHBvcnRzID0ge1xuICBmb286ICdoZWxsbycsXG4gIGJhcigpIHtcbiAgICByZXR1cm4gdHJ1ZTtcbiAgfVxufTtcbiIsIiJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiNkVBQUEsTUFBTSxDQUFDLE9BQU8sR0FBRztBQUNqQixFQUFFLEdBQUcsRUFBRSxJQUFPO0FBQ2QsRUFBRSxHQUFHLEdBQUc7QUFDUixJQUFJLE9BQU87QUFDWDtBQUNBIiwiaWdub3JlTGlzdCI6WzFdfQ=="
 `;
 
 exports[`should be able to set a custom imported addToDictionary helper > for commonjs-require 1`] = `
@@ -1365,6 +1401,24 @@ foo({
 //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIiwiIl0sInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGZvbyB9IGZyb20gXCJteS1tb2R1bGUuanNcIjtcblxuLy8gY29uc3QgY29uc3RhbnQgPSBcInNvbWUgc3RyaW5nXCI7XG5jb25zdCBjb25zdGFudCA9IFwic29tZSBzdHJpbmdcIjtcblxuZm9vKHtcbiAgLy8gYmFyOiBcImFiY1wiLFxuICBiYXI6IFwiYWJjXCIsXG4gIC8vIGJhejogYHNvbWV0aGluZyR7Y29uc3RhbnR9NDU2YCxcbiAgYmF6OiBgc29tZXRoaW5nJHtjb25zdGFudH00NTZgLFxuICAvLyBiYXQ6IGZvb2AxMjMke2NvbnN0YW50fWFub3RoZXIgdGhpbmdgLFxuICBiYXQ6IGZvb2AxMjMke2NvbnN0YW50fWFub3RoZXIgdGhpbmdgLFxufSk7XG4iLCIiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6ImlIQUFBLFNBQVMsR0FBRyxRQUFRLGNBQWM7QUFDbEM7QUFDQTtBQUNBLE1BQU0sUUFBUSxHQUFHLElBQWE7QUFDOUI7QUFDQSxHQUFHLENBQUM7QUFDSjtBQUNBLEVBQUUsR0FBRyxFQUFFLElBQUs7QUFDWjtBQUNBLEVBQUUsR0FBRyxHQUFHLE9BQVMsRUFBRSxRQUFRLENBQUMsR0FBRztBQUMvQjtBQUNBLEVBQUUsR0FBRyxFQUFFLEdBQUcsS0FBQyxBQUFHLEVBQUUsUUFBUSxBQUFDLEFBQWE7QUFDdEMiLCJpZ25vcmVMaXN0IjpbMV19"
 `;
 
+exports[`the CJS version should transform code correctly > for commonjs-exports 1`] = `
+"const{$}=require(' datadog:privacy-helpers.cjs');const D=$(['hello']);exports.foo = D[0];
+exports.bar = function() {
+  return true;
+};
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIiwiIl0sInNvdXJjZXNDb250ZW50IjpbImV4cG9ydHMuZm9vID0gJ2hlbGxvJztcbmV4cG9ydHMuYmFyID0gZnVuY3Rpb24oKSB7XG4gIHJldHVybiB0cnVlO1xufTtcbiIsIiJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoic0VBQUEsT0FBTyxDQUFDLEdBQUcsR0FBRyxJQUFPO0FBQ3JCLE9BQU8sQ0FBQyxHQUFHLEdBQUcsV0FBVztBQUN6QixFQUFFLE9BQU87QUFDVCIsImlnbm9yZUxpc3QiOlsxXX0="
+`;
+
+exports[`the CJS version should transform code correctly > for commonjs-module-exports 1`] = `
+"const{$}=require(' datadog:privacy-helpers.cjs');const D=$(['hello']);module.exports = {
+  foo: D[0],
+  bar() {
+    return true;
+  }
+};
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIiwiIl0sInNvdXJjZXNDb250ZW50IjpbIm1vZHVsZS5leHBvcnRzID0ge1xuICBmb286ICdoZWxsbycsXG4gIGJhcigpIHtcbiAgICByZXR1cm4gdHJ1ZTtcbiAgfVxufTtcbiIsIiJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoic0VBQUEsTUFBTSxDQUFDLE9BQU8sR0FBRztBQUNqQixFQUFFLEdBQUcsRUFBRSxJQUFPO0FBQ2QsRUFBRSxHQUFHLEdBQUc7QUFDUixJQUFJLE9BQU87QUFDWDtBQUNBIiwiaWdub3JlTGlzdCI6WzFdfQ=="
+`;
+
 exports[`the CJS version should transform code correctly > for commonjs-require 1`] = `
 "const{$}=require(' datadog:privacy-helpers.cjs');const D=$(['test']);const foo = require('foo-module');
 foo(D[0]);
@@ -2037,6 +2091,24 @@ foo({
   bat: foo(D[3], constant),
 });
 //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIiwiIl0sInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGZvbyB9IGZyb20gXCJteS1tb2R1bGUuanNcIjtcblxuLy8gY29uc3QgY29uc3RhbnQgPSBcInNvbWUgc3RyaW5nXCI7XG5jb25zdCBjb25zdGFudCA9IFwic29tZSBzdHJpbmdcIjtcblxuZm9vKHtcbiAgLy8gYmFyOiBcImFiY1wiLFxuICBiYXI6IFwiYWJjXCIsXG4gIC8vIGJhejogYHNvbWV0aGluZyR7Y29uc3RhbnR9NDU2YCxcbiAgYmF6OiBgc29tZXRoaW5nJHtjb25zdGFudH00NTZgLFxuICAvLyBiYXQ6IGZvb2AxMjMke2NvbnN0YW50fWFub3RoZXIgdGhpbmdgLFxuICBiYXQ6IGZvb2AxMjMke2NvbnN0YW50fWFub3RoZXIgdGhpbmdgLFxufSk7XG4iLCIiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6ImlIQUFBLFNBQVMsR0FBRyxRQUFRLGNBQWM7QUFDbEM7QUFDQTtBQUNBLE1BQU0sUUFBUSxHQUFHLElBQWE7QUFDOUI7QUFDQSxHQUFHLENBQUM7QUFDSjtBQUNBLEVBQUUsR0FBRyxFQUFFLElBQUs7QUFDWjtBQUNBLEVBQUUsR0FBRyxHQUFHLE9BQVMsRUFBRSxRQUFRLENBQUMsR0FBRztBQUMvQjtBQUNBLEVBQUUsR0FBRyxFQUFFLEdBQUcsS0FBQyxBQUFHLEVBQUUsUUFBUSxBQUFDLEFBQWE7QUFDdEMiLCJpZ25vcmVMaXN0IjpbMV19"
+`;
+
+exports[`the ESM version should transform code correctly > for commonjs-exports 1`] = `
+"const{$}=require(' datadog:privacy-helpers.cjs');const D=$(['hello']);exports.foo = D[0];
+exports.bar = function() {
+  return true;
+};
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIiwiIl0sInNvdXJjZXNDb250ZW50IjpbImV4cG9ydHMuZm9vID0gJ2hlbGxvJztcbmV4cG9ydHMuYmFyID0gZnVuY3Rpb24oKSB7XG4gIHJldHVybiB0cnVlO1xufTtcbiIsIiJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoic0VBQUEsT0FBTyxDQUFDLEdBQUcsR0FBRyxJQUFPO0FBQ3JCLE9BQU8sQ0FBQyxHQUFHLEdBQUcsV0FBVztBQUN6QixFQUFFLE9BQU87QUFDVCIsImlnbm9yZUxpc3QiOlsxXX0="
+`;
+
+exports[`the ESM version should transform code correctly > for commonjs-module-exports 1`] = `
+"const{$}=require(' datadog:privacy-helpers.cjs');const D=$(['hello']);module.exports = {
+  foo: D[0],
+  bar() {
+    return true;
+  }
+};
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIiwiIl0sInNvdXJjZXNDb250ZW50IjpbIm1vZHVsZS5leHBvcnRzID0ge1xuICBmb286ICdoZWxsbycsXG4gIGJhcigpIHtcbiAgICByZXR1cm4gdHJ1ZTtcbiAgfVxufTtcbiIsIiJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoic0VBQUEsTUFBTSxDQUFDLE9BQU8sR0FBRztBQUNqQixFQUFFLEdBQUcsRUFBRSxJQUFPO0FBQ2QsRUFBRSxHQUFHLEdBQUc7QUFDUixJQUFJLE9BQU87QUFDWDtBQUNBIiwiaWdub3JlTGlzdCI6WzFdfQ=="
 `;
 
 exports[`the ESM version should transform code correctly > for commonjs-require 1`] = `

--- a/tests/unit/yarn.lock
+++ b/tests/unit/yarn.lock
@@ -92,7 +92,7 @@ __metadata:
 
 "@datadog/instrumentation-test-plugin@file:../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::locator=%40datadog%2Fjs-instrumentation-wasm-unit-tests%40workspace%3A.":
   version: 0.1
-  resolution: "@datadog/instrumentation-test-plugin@file:../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=4887fd&locator=%40datadog%2Fjs-instrumentation-wasm-unit-tests%40workspace%3A."
+  resolution: "@datadog/instrumentation-test-plugin@file:../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=3a2be8&locator=%40datadog%2Fjs-instrumentation-wasm-unit-tests%40workspace%3A."
   dependencies:
     unplugin: "npm:^2.3.4"
   peerDependencies:
@@ -118,7 +118,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/a13a348559e205a5c496e5f42f45844a5a9973512bf5ce6449e3d1c87c7411026133f2059797711c8c337a711029a51dd17de7cb791307a93ba5b25dff467c84
+  checksum: 10c0/4f0589a75c591117f74463370d2c7d27705c570677ee571e82f23e747b9495f74f662b93ff860e0725f5a94541b9a23e1985c81406e42ec9ed2a75985224766a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Feature / Major Change / Refactor / Optimization
- [x] Bug Fix
- [ ] Documentation Update

## Description

Currently, we only detect that a module is CommonJS if it uses `require()`. However, it's not unusual for a project to include at least a few modules that only export things, and don't import anything. In such a project, today, we'll infer that those modules are ESM, even if they should be CJS.

This PR fixes that by checking for `exports` and `module.exports`, and treating the presence of either as evidence that the module should be treated as CJS. (As usual, the presence of ESM `import` or `export` overrides this, so we won't be tripped up if the module really is ESM.)

Tests are included.