### PR TITLE
Report privacy dictionary size

### DIFF
--- a/rust/js-instrumentation-shared/src/instrumentation_output.rs
+++ b/rust/js-instrumentation-shared/src/instrumentation_output.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct InstrumentationOutput {
     /// The filename or id of the code that was instrumented.
     pub id: String,
@@ -12,4 +13,6 @@ pub struct InstrumentationOutput {
     /// map was not generated for some reason (e.g. because the input referenced an
     /// external source map), no source map is returned.
     pub map: Option<String>,
+    /// The number of items in the privacy dictionary generated for this file.
+    pub privacy_dictionary_size: usize,
 }

--- a/rust/js-instrumentation-transform/src/instrumentation_transform.rs
+++ b/rust/js-instrumentation-transform/src/instrumentation_transform.rs
@@ -66,6 +66,7 @@ pub fn apply_transform(
     let dictionary_identifier =
         identifier_tracker.new_unused_identifier(DEFAULT_DICTIONARY_IDENTIFIER);
     let dictionary = OptimizedDictionary::build(&dictionary_identifier, dictionary_tracker.strings);
+    let privacy_dictionary_size = dictionary.strings.len();
 
     let helper_identifier =
         identifier_tracker.new_unused_identifier(default_add_to_dictionary_helper);
@@ -140,6 +141,7 @@ pub fn apply_transform(
         id: input.id.clone(),
         code: instrumented_code,
         map: serialized_source_map,
+        privacy_dictionary_size,
     })
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,8 @@ export interface InstrumentationOutput {
    * external source map), no source map is returned.
    */
   map?: string;
+  /** The number of items in the privacy dictionary generated for this file. */
+  privacyDictionarySize: number;
 }
 
 export interface InputOptions {

--- a/tests/instrumentation-test-plugin/src/core/unplugin.ts
+++ b/tests/instrumentation-test-plugin/src/core/unplugin.ts
@@ -114,8 +114,7 @@ export const unpluginFactory: UnpluginFactory<UnpluginOptions> = options => {
       order: 'pre',
 
       handler(code, id) {
-        const result = instrument({ id, code }, instrumentationOptions);
-        return { code: result.code, map: result.map };
+        return instrument({ id, code }, instrumentationOptions);
       },
     },
   };

--- a/tests/instrumentation-test-plugin/yarn.lock
+++ b/tests/instrumentation-test-plugin/yarn.lock
@@ -150,8 +150,8 @@ __metadata:
 
 "@datadog/js-instrumentation-wasm@file:../../artifacts/@datadog-js-instrumentation-wasm.tgz::locator=%40datadog%2Finstrumentation-test-plugin%40workspace%3A.":
   version: 1.0.2
-  resolution: "@datadog/js-instrumentation-wasm@file:../../artifacts/@datadog-js-instrumentation-wasm.tgz#../../artifacts/@datadog-js-instrumentation-wasm.tgz::hash=c6e25e&locator=%40datadog%2Finstrumentation-test-plugin%40workspace%3A."
-  checksum: 10c0/224dc7db8871342f87155991c27c06de7718bc36912ecc76d22398f4e1620faeca5e092bde192c32965ef1f3bc4c92be59c1c84518fe746bb11622c96932ac3d
+  resolution: "@datadog/js-instrumentation-wasm@file:../../artifacts/@datadog-js-instrumentation-wasm.tgz#../../artifacts/@datadog-js-instrumentation-wasm.tgz::hash=c0cef1&locator=%40datadog%2Finstrumentation-test-plugin%40workspace%3A."
+  checksum: 10c0/fced34726d22dff6c3ef802a33d533cf1cd6f62ef252ef86c39d61fc77272445fb22a070b8378b26c1e02b06bc2275c658dbc6248bde996b242bd05ade89b782
   languageName: node
   linkType: hard
 

--- a/tests/integration/esbuild/yarn.lock
+++ b/tests/integration/esbuild/yarn.lock
@@ -93,7 +93,7 @@ __metadata:
 
 "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::locator=esbuild-project%40workspace%3A.":
   version: 0.1
-  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=3a2be8&locator=esbuild-project%40workspace%3A."
+  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=4c683f&locator=esbuild-project%40workspace%3A."
   dependencies:
     unplugin: "npm:^2.3.4"
   peerDependencies:
@@ -119,7 +119,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/4f0589a75c591117f74463370d2c7d27705c570677ee571e82f23e747b9495f74f662b93ff860e0725f5a94541b9a23e1985c81406e42ec9ed2a75985224766a
+  checksum: 10c0/e1f660816f75b7dac159362ff7f44e161bc4e600bcf55c3613f85f3ca2c1a5e165eb386d6bfa8ff29c5601d62ee3d934f6edb0029409c18cfc9f12a57cbee0b8
   languageName: node
   linkType: hard
 

--- a/tests/integration/vite-with-yarn-pnp/yarn.lock
+++ b/tests/integration/vite-with-yarn-pnp/yarn.lock
@@ -282,7 +282,7 @@ __metadata:
 
 "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::locator=vite-project%40workspace%3A.":
   version: 0.1
-  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=3a2be8&locator=vite-project%40workspace%3A."
+  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=4c683f&locator=vite-project%40workspace%3A."
   dependencies:
     unplugin: "npm:^2.3.4"
   peerDependencies:
@@ -308,7 +308,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/4f0589a75c591117f74463370d2c7d27705c570677ee571e82f23e747b9495f74f662b93ff860e0725f5a94541b9a23e1985c81406e42ec9ed2a75985224766a
+  checksum: 10c0/e1f660816f75b7dac159362ff7f44e161bc4e600bcf55c3613f85f3ca2c1a5e165eb386d6bfa8ff29c5601d62ee3d934f6edb0029409c18cfc9f12a57cbee0b8
   languageName: node
   linkType: hard
 

--- a/tests/integration/vite/yarn.lock
+++ b/tests/integration/vite/yarn.lock
@@ -282,7 +282,7 @@ __metadata:
 
 "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::locator=vite-project%40workspace%3A.":
   version: 0.1
-  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=3a2be8&locator=vite-project%40workspace%3A."
+  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=4c683f&locator=vite-project%40workspace%3A."
   dependencies:
     unplugin: "npm:^2.3.4"
   peerDependencies:
@@ -308,7 +308,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/4f0589a75c591117f74463370d2c7d27705c570677ee571e82f23e747b9495f74f662b93ff860e0725f5a94541b9a23e1985c81406e42ec9ed2a75985224766a
+  checksum: 10c0/e1f660816f75b7dac159362ff7f44e161bc4e600bcf55c3613f85f3ca2c1a5e165eb386d6bfa8ff29c5601d62ee3d934f6edb0029409c18cfc9f12a57cbee0b8
   languageName: node
   linkType: hard
 

--- a/tests/integration/webpack/yarn.lock
+++ b/tests/integration/webpack/yarn.lock
@@ -93,7 +93,7 @@ __metadata:
 
 "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::locator=webpack-react-typescript-example%40workspace%3A.":
   version: 0.1
-  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=3a2be8&locator=webpack-react-typescript-example%40workspace%3A."
+  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=4c683f&locator=webpack-react-typescript-example%40workspace%3A."
   dependencies:
     unplugin: "npm:^2.3.4"
   peerDependencies:
@@ -119,7 +119,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/4f0589a75c591117f74463370d2c7d27705c570677ee571e82f23e747b9495f74f662b93ff860e0725f5a94541b9a23e1985c81406e42ec9ed2a75985224766a
+  checksum: 10c0/e1f660816f75b7dac159362ff7f44e161bc4e600bcf55c3613f85f3ca2c1a5e165eb386d6bfa8ff29c5601d62ee3d934f6edb0029409c18cfc9f12a57cbee0b8
   languageName: node
   linkType: hard
 

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -26,8 +26,9 @@ const transformCJS = unpluginCJS.raw(pluginOptions).transform.handler;
 describe('the ESM version should transform code correctly', async () => {
   await walkDir(fixtureDir, async (testCase) => {
     it(`for ${testCase.dir}`, async () => {
-      const { code } = transformESM(testCase.code, testCase.name);
-      expect(code).toMatchSnapshot();
+      const result = transformESM(testCase.code, testCase.name);
+      console.log('RESULT', result);
+      expect(result.code).toMatchSnapshot();
     });
   });
 });

--- a/tests/unit/yarn.lock
+++ b/tests/unit/yarn.lock
@@ -92,7 +92,7 @@ __metadata:
 
 "@datadog/instrumentation-test-plugin@file:../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::locator=%40datadog%2Fjs-instrumentation-wasm-unit-tests%40workspace%3A.":
   version: 0.1
-  resolution: "@datadog/instrumentation-test-plugin@file:../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=3a2be8&locator=%40datadog%2Fjs-instrumentation-wasm-unit-tests%40workspace%3A."
+  resolution: "@datadog/instrumentation-test-plugin@file:../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=4c683f&locator=%40datadog%2Fjs-instrumentation-wasm-unit-tests%40workspace%3A."
   dependencies:
     unplugin: "npm:^2.3.4"
   peerDependencies:
@@ -118,7 +118,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/4f0589a75c591117f74463370d2c7d27705c570677ee571e82f23e747b9495f74f662b93ff860e0725f5a94541b9a23e1985c81406e42ec9ed2a75985224766a
+  checksum: 10c0/e1f660816f75b7dac159362ff7f44e161bc4e600bcf55c3613f85f3ca2c1a5e165eb386d6bfa8ff29c5601d62ee3d934f6edb0029409c18cfc9f12a57cbee0b8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature / Major Change / Refactor / Optimization
- [ ] Bug Fix
- [ ] Documentation Update

## Description

This PR adds a new property on `TransformOutput`: `privacyDictionarySize`. It reports the actual number of items that appear in the privacy dictionary for the transformed file. We can use this to report statistics to the user, and to warn them if the privacy dictionary will be totally empty, which almost certainly indicates a configuration issue.