### PR TITLE
Handle shebangs when generating header content

### DIFF
--- a/rust/js-instrumentation-shared/src/input_file.rs
+++ b/rust/js-instrumentation-shared/src/input_file.rs
@@ -49,12 +49,23 @@ impl<'a> InputFile<'a> {
         }
     }
 
-    pub fn next_char_pos(self: &mut Self, pos: BytePos) -> BytePos {
+    pub fn next_char_pos(self: &Self, pos: BytePos) -> BytePos {
         let maybe_next_char_pos = self.map.next_point(pos.span()).hi;
         if maybe_next_char_pos > self.end_pos {
             self.end_pos
         } else {
             maybe_next_char_pos
+        }
+    }
+
+    pub fn next_line_start(self: &Self, pos: BytePos) -> BytePos {
+        let pos_as_span = Span { lo: pos, hi: pos };
+        let extended_span = self.map.span_extend_to_next_char(pos_as_span, '\n');
+        if extended_span == pos_as_span {
+            // No newline found; use the end of the file.
+            self.end_pos
+        } else {
+            self.next_char_pos(extended_span.hi)
         }
     }
 

--- a/tests/fixtures/shebang-empty-file/input.js
+++ b/tests/fixtures/shebang-empty-file/input.js
@@ -1,0 +1,1 @@
+#!/usr/bin/env node

--- a/tests/fixtures/shebang-empty-file/output.js
+++ b/tests/fixtures/shebang-empty-file/output.js
@@ -1,0 +1,1 @@
+#!/usr/bin/env node

--- a/tests/fixtures/shebang/input.js
+++ b/tests/fixtures/shebang/input.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+const foo = 'foo';

--- a/tests/fixtures/shebang/output.js
+++ b/tests/fixtures/shebang/output.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import{$}from'datadog:privacy-helpers.mjs';const D=$(['foo']);const foo = D[0];

--- a/tests/instrumentation-test-plugin/yarn.lock
+++ b/tests/instrumentation-test-plugin/yarn.lock
@@ -150,8 +150,8 @@ __metadata:
 
 "@datadog/js-instrumentation-wasm@file:../../artifacts/@datadog-js-instrumentation-wasm.tgz::locator=%40datadog%2Finstrumentation-test-plugin%40workspace%3A.":
   version: 1.0.6
-  resolution: "@datadog/js-instrumentation-wasm@file:../../artifacts/@datadog-js-instrumentation-wasm.tgz#../../artifacts/@datadog-js-instrumentation-wasm.tgz::hash=135749&locator=%40datadog%2Finstrumentation-test-plugin%40workspace%3A."
-  checksum: 10c0/1f55127e423a563c4cf775d7816c3913d972a6aebf2b3c3cb77ba81fb20b215fb78ca406070bf67a9d648075a2cac0cd2d4cca9464c798e427d14d848c15a8a8
+  resolution: "@datadog/js-instrumentation-wasm@file:../../artifacts/@datadog-js-instrumentation-wasm.tgz#../../artifacts/@datadog-js-instrumentation-wasm.tgz::hash=78c073&locator=%40datadog%2Finstrumentation-test-plugin%40workspace%3A."
+  checksum: 10c0/8bbaac5d3fd285221a1fd4b239a1aad778d1bb6e342caace714287376df8584cc1e308f2208edee9cdb03e8be0627441e843258c0f6b682c61344e96490b35f1
   languageName: node
   linkType: hard
 

--- a/tests/integration/esbuild/yarn.lock
+++ b/tests/integration/esbuild/yarn.lock
@@ -93,7 +93,7 @@ __metadata:
 
 "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::locator=esbuild-project%40workspace%3A.":
   version: 0.1
-  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=36c39a&locator=esbuild-project%40workspace%3A."
+  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=184f72&locator=esbuild-project%40workspace%3A."
   dependencies:
     unplugin: "npm:^2.3.4"
   peerDependencies:
@@ -119,7 +119,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/871215c036f6c5a44c64788ac2bb6993756e5e121875d24c8dc78ec3c010600d34e8df4b9c92385815e1252a96f85c89773a30c1efde933e8daf9777800a203a
+  checksum: 10c0/a21280749c332c86677bba37b76bbdfdfee0a54a40e4fa5b6cd4037ac5684474e62c40b5739752995024a56265207260aa0861873a332260a21fa9e561629d9c
   languageName: node
   linkType: hard
 

--- a/tests/integration/vite-with-yarn-pnp/yarn.lock
+++ b/tests/integration/vite-with-yarn-pnp/yarn.lock
@@ -282,7 +282,7 @@ __metadata:
 
 "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::locator=vite-project%40workspace%3A.":
   version: 0.1
-  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=36c39a&locator=vite-project%40workspace%3A."
+  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=184f72&locator=vite-project%40workspace%3A."
   dependencies:
     unplugin: "npm:^2.3.4"
   peerDependencies:
@@ -308,7 +308,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/871215c036f6c5a44c64788ac2bb6993756e5e121875d24c8dc78ec3c010600d34e8df4b9c92385815e1252a96f85c89773a30c1efde933e8daf9777800a203a
+  checksum: 10c0/a21280749c332c86677bba37b76bbdfdfee0a54a40e4fa5b6cd4037ac5684474e62c40b5739752995024a56265207260aa0861873a332260a21fa9e561629d9c
   languageName: node
   linkType: hard
 

--- a/tests/integration/vite/yarn.lock
+++ b/tests/integration/vite/yarn.lock
@@ -282,7 +282,7 @@ __metadata:
 
 "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::locator=vite-project%40workspace%3A.":
   version: 0.1
-  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=36c39a&locator=vite-project%40workspace%3A."
+  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=184f72&locator=vite-project%40workspace%3A."
   dependencies:
     unplugin: "npm:^2.3.4"
   peerDependencies:
@@ -308,7 +308,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/871215c036f6c5a44c64788ac2bb6993756e5e121875d24c8dc78ec3c010600d34e8df4b9c92385815e1252a96f85c89773a30c1efde933e8daf9777800a203a
+  checksum: 10c0/a21280749c332c86677bba37b76bbdfdfee0a54a40e4fa5b6cd4037ac5684474e62c40b5739752995024a56265207260aa0861873a332260a21fa9e561629d9c
   languageName: node
   linkType: hard
 

--- a/tests/integration/webpack/yarn.lock
+++ b/tests/integration/webpack/yarn.lock
@@ -93,7 +93,7 @@ __metadata:
 
 "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::locator=webpack-react-typescript-example%40workspace%3A.":
   version: 0.1
-  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=36c39a&locator=webpack-react-typescript-example%40workspace%3A."
+  resolution: "@datadog/instrumentation-test-plugin@file:../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=184f72&locator=webpack-react-typescript-example%40workspace%3A."
   dependencies:
     unplugin: "npm:^2.3.4"
   peerDependencies:
@@ -119,7 +119,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/871215c036f6c5a44c64788ac2bb6993756e5e121875d24c8dc78ec3c010600d34e8df4b9c92385815e1252a96f85c89773a30c1efde933e8daf9777800a203a
+  checksum: 10c0/a21280749c332c86677bba37b76bbdfdfee0a54a40e4fa5b6cd4037ac5684474e62c40b5739752995024a56265207260aa0861873a332260a21fa9e561629d9c
   languageName: node
   linkType: hard
 

--- a/tests/unit/__snapshots__/index.test.ts.snap
+++ b/tests/unit/__snapshots__/index.test.ts.snap
@@ -567,6 +567,17 @@ const addQuotes = (string, hasQuotes) =>
 //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIl0sInNvdXJjZXNDb250ZW50IjpbImltcG9ydCBjb21wYWN0IGZyb20gJ2xvZGFzaC9jb21wYWN0JztcblxuZXhwb3J0IGNvbnN0IFBBVFRFUk4gPSAvWzooKVwiXFxcXF0vZztcblxuY29uc3QgYWRkUXVvdGVzID0gKHN0cmluZywgaGFzUXVvdGVzKSA9PlxuICBoYXNRdW90ZXMgPyBgXCIke3N0cmluZ31cImAgOiBzdHJpbmc7XG4iXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEseUNBS2UsTUFMZixPQUFPLE9BQU8sTUFBTSxnQkFBZ0I7QUFDcEM7QUFDQSxPQUFPLE1BQU0sT0FBTyxHQUFHO0FBQ3ZCO0FBQ0EsTUFBTSxTQUFTLEdBQUcsQ0FBQyxNQUFNLEVBQUUsU0FBUztBQUNwQyxFQUFFLFNBQVMsSUFBSSxDQUFDLEVBQUUsTUFBTSxDQUFDLENBQUMsSUFBSSxNQUFNIn0="
 `;
 
+exports[`should be able to set a custom expression addToDictionary helper > for shebang 1`] = `
+"#!/usr/bin/env node
+const $=(v) => console.log(v);const D=$(['foo']);const foo = D[0];
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIl0sInNvdXJjZXNDb250ZW50IjpbIiMhL3Vzci9iaW4vZW52IG5vZGVcbmNvbnN0IGZvbyA9ICdmb28nO1xuIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBO0FBQ0EseUNBQVksUUFBWixNQUFNLEdBQUcsR0FBRyxJQUFLIn0="
+`;
+
+exports[`should be able to set a custom expression addToDictionary helper > for shebang-empty-file 1`] = `
+"#!/usr/bin/env node
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIl0sInNvdXJjZXNDb250ZW50IjpbIiMhL3Vzci9iaW4vZW52IG5vZGVcbiJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSJ9"
+`;
+
 exports[`should be able to set a custom expression addToDictionary helper > for string-literals 1`] = `
 "const $=(v) => console.log(v);const D=$(["appendix","gem\`'\\"\\u{6F}","cat\\r\\n\\tdog","observe",'quarrel','fizz"\\'"',"karat",'bowling',"egg'\\"'","macrame","nanobot","pacific","hammer","image","jewel","labor"]);const foo = () => {};
 
@@ -1396,6 +1407,17 @@ export const PATTERN = /[:()"\\\\]/g;
 const addQuotes = (string, hasQuotes) =>
   hasQuotes ? \`"\${string}"\` : string;
 //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIl0sInNvdXJjZXNDb250ZW50IjpbImltcG9ydCBjb21wYWN0IGZyb20gJ2xvZGFzaC9jb21wYWN0JztcblxuZXhwb3J0IGNvbnN0IFBBVFRFUk4gPSAvWzooKVwiXFxcXF0vZztcblxuY29uc3QgYWRkUXVvdGVzID0gKHN0cmluZywgaGFzUXVvdGVzKSA9PlxuICBoYXNRdW90ZXMgPyBgXCIke3N0cmluZ31cImAgOiBzdHJpbmc7XG4iXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsaUVBS2UsTUFMZixPQUFPLE9BQU8sTUFBTSxnQkFBZ0I7QUFDcEM7QUFDQSxPQUFPLE1BQU0sT0FBTyxHQUFHO0FBQ3ZCO0FBQ0EsTUFBTSxTQUFTLEdBQUcsQ0FBQyxNQUFNLEVBQUUsU0FBUztBQUNwQyxFQUFFLFNBQVMsSUFBSSxDQUFDLEVBQUUsTUFBTSxDQUFDLENBQUMsSUFBSSxNQUFNIn0="
+`;
+
+exports[`should be able to set a custom imported addToDictionary helper > for shebang 1`] = `
+"#!/usr/bin/env node
+import{addToDictionary as $}from'@custom/helpers.mjs';const D=$(['foo']);const foo = D[0];
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIl0sInNvdXJjZXNDb250ZW50IjpbIiMhL3Vzci9iaW4vZW52IG5vZGVcbmNvbnN0IGZvbyA9ICdmb28nO1xuIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBO0FBQ0EsaUVBQVksUUFBWixNQUFNLEdBQUcsR0FBRyxJQUFLIn0="
+`;
+
+exports[`should be able to set a custom imported addToDictionary helper > for shebang-empty-file 1`] = `
+"#!/usr/bin/env node
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIl0sInNvdXJjZXNDb250ZW50IjpbIiMhL3Vzci9iaW4vZW52IG5vZGVcbiJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSJ9"
 `;
 
 exports[`should be able to set a custom imported addToDictionary helper > for string-literals 1`] = `
@@ -2229,6 +2251,17 @@ const addQuotes = (string, hasQuotes) =>
 //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIl0sInNvdXJjZXNDb250ZW50IjpbImltcG9ydCBjb21wYWN0IGZyb20gJ2xvZGFzaC9jb21wYWN0JztcblxuZXhwb3J0IGNvbnN0IFBBVFRFUk4gPSAvWzooKVwiXFxcXF0vZztcblxuY29uc3QgYWRkUXVvdGVzID0gKHN0cmluZywgaGFzUXVvdGVzKSA9PlxuICBoYXNRdW90ZXMgPyBgXCIke3N0cmluZ31cImAgOiBzdHJpbmc7XG4iXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsdURBS2UsTUFMZixPQUFPLE9BQU8sTUFBTSxnQkFBZ0I7QUFDcEM7QUFDQSxPQUFPLE1BQU0sT0FBTyxHQUFHO0FBQ3ZCO0FBQ0EsTUFBTSxTQUFTLEdBQUcsQ0FBQyxNQUFNLEVBQUUsU0FBUztBQUNwQyxFQUFFLFNBQVMsSUFBSSxDQUFDLEVBQUUsTUFBTSxDQUFDLENBQUMsSUFBSSxNQUFNIn0="
 `;
 
+exports[`the CJS version should transform code correctly > for shebang 1`] = `
+"#!/usr/bin/env node
+import{$}from' datadog:privacy-helpers.mjs';const D=$(['foo']);const foo = D[0];
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIl0sInNvdXJjZXNDb250ZW50IjpbIiMhL3Vzci9iaW4vZW52IG5vZGVcbmNvbnN0IGZvbyA9ICdmb28nO1xuIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBO0FBQ0EsdURBQVksUUFBWixNQUFNLEdBQUcsR0FBRyxJQUFLIn0="
+`;
+
+exports[`the CJS version should transform code correctly > for shebang-empty-file 1`] = `
+"#!/usr/bin/env node
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIl0sInNvdXJjZXNDb250ZW50IjpbIiMhL3Vzci9iaW4vZW52IG5vZGVcbiJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSJ9"
+`;
+
 exports[`the CJS version should transform code correctly > for string-literals 1`] = `
 "import{$}from' datadog:privacy-helpers.mjs';const D=$(["appendix","gem\`'\\"\\u{6F}","cat\\r\\n\\tdog","observe",'quarrel','fizz"\\'"',"karat",'bowling',"egg'\\"'","macrame","nanobot","pacific","hammer","image","jewel","labor"]);const foo = () => {};
 
@@ -3058,6 +3091,17 @@ export const PATTERN = /[:()"\\\\]/g;
 const addQuotes = (string, hasQuotes) =>
   hasQuotes ? \`"\${string}"\` : string;
 //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIl0sInNvdXJjZXNDb250ZW50IjpbImltcG9ydCBjb21wYWN0IGZyb20gJ2xvZGFzaC9jb21wYWN0JztcblxuZXhwb3J0IGNvbnN0IFBBVFRFUk4gPSAvWzooKVwiXFxcXF0vZztcblxuY29uc3QgYWRkUXVvdGVzID0gKHN0cmluZywgaGFzUXVvdGVzKSA9PlxuICBoYXNRdW90ZXMgPyBgXCIke3N0cmluZ31cImAgOiBzdHJpbmc7XG4iXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsdURBS2UsTUFMZixPQUFPLE9BQU8sTUFBTSxnQkFBZ0I7QUFDcEM7QUFDQSxPQUFPLE1BQU0sT0FBTyxHQUFHO0FBQ3ZCO0FBQ0EsTUFBTSxTQUFTLEdBQUcsQ0FBQyxNQUFNLEVBQUUsU0FBUztBQUNwQyxFQUFFLFNBQVMsSUFBSSxDQUFDLEVBQUUsTUFBTSxDQUFDLENBQUMsSUFBSSxNQUFNIn0="
+`;
+
+exports[`the ESM version should transform code correctly > for shebang 1`] = `
+"#!/usr/bin/env node
+import{$}from' datadog:privacy-helpers.mjs';const D=$(['foo']);const foo = D[0];
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIl0sInNvdXJjZXNDb250ZW50IjpbIiMhL3Vzci9iaW4vZW52IG5vZGVcbmNvbnN0IGZvbyA9ICdmb28nO1xuIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBO0FBQ0EsdURBQVksUUFBWixNQUFNLEdBQUcsR0FBRyxJQUFLIn0="
+`;
+
+exports[`the ESM version should transform code correctly > for shebang-empty-file 1`] = `
+"#!/usr/bin/env node
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LmpzIl0sInNvdXJjZXNDb250ZW50IjpbIiMhL3Vzci9iaW4vZW52IG5vZGVcbiJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSJ9"
 `;
 
 exports[`the ESM version should transform code correctly > for string-literals 1`] = `

--- a/tests/unit/yarn.lock
+++ b/tests/unit/yarn.lock
@@ -92,7 +92,7 @@ __metadata:
 
 "@datadog/instrumentation-test-plugin@file:../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::locator=%40datadog%2Fjs-instrumentation-wasm-unit-tests%40workspace%3A.":
   version: 0.1
-  resolution: "@datadog/instrumentation-test-plugin@file:../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=36c39a&locator=%40datadog%2Fjs-instrumentation-wasm-unit-tests%40workspace%3A."
+  resolution: "@datadog/instrumentation-test-plugin@file:../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz#../instrumentation-test-plugin/artifacts/@datadog-instrumentation-test-plugin.tgz::hash=184f72&locator=%40datadog%2Fjs-instrumentation-wasm-unit-tests%40workspace%3A."
   dependencies:
     unplugin: "npm:^2.3.4"
   peerDependencies:
@@ -118,7 +118,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/871215c036f6c5a44c64788ac2bb6993756e5e121875d24c8dc78ec3c010600d34e8df4b9c92385815e1252a96f85c89773a30c1efde933e8daf9777800a203a
+  checksum: 10c0/a21280749c332c86677bba37b76bbdfdfee0a54a40e4fa5b6cd4037ac5684474e62c40b5739752995024a56265207260aa0861873a332260a21fa9e561629d9c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature / Major Change / Refactor / Optimization
- [ ] Bug Fix
- [ ] Documentation Update

## Description

Currently, if a JavaScript file contains a shebang, we insert the helper import and dictionary _before_ the shebang. So this:

```ts
#!/usr/bin/env node
const foo = 'bar'
```

Becomes this:

```ts
import{$}from'datadog:privacy-helpers.mjs';const D=$(['foo']);#!/usr/bin/env node
const foo = D[0]
```

However, this is wrong; the shebang needs to be by itself, on the first line of the file. So, the output should be this:

```ts
#!/usr/bin/env node
import{$}from'datadog:privacy-helpers.mjs';const D=$(['foo']);const foo = D[0]
```

This PR adds code to check for shebangs and handle this case correctly.

## How to reproduce and testing

Test cases are included. (Both for files involving shebangs, and for the edge case where the shebang is the only thing in the file.)